### PR TITLE
Add macOS port (AppKit/rumps)

### DIFF
--- a/claude_usage/collector.py
+++ b/claude_usage/collector.py
@@ -154,22 +154,45 @@ def get_active_sessions(claude_dir: str) -> list[dict]:
     return active
 
 
+def _load_credentials(claude_dir: str) -> str | None:
+    """Load OAuth access token from credentials file or macOS Keychain."""
+    # 1. Try the credentials file (Linux + macOS)
+    creds_path = os.path.join(claude_dir, ".credentials.json")
+    if os.path.isfile(creds_path):
+        try:
+            with open(creds_path) as f:
+                creds = json.load(f)
+            return creds["claudeAiOauth"]["accessToken"]
+        except (json.JSONDecodeError, KeyError, OSError):
+            return None
+
+    # 2. Try macOS Keychain (credentials stored by Claude Code for macOS)
+    if os.uname().sysname == "Darwin":
+        try:
+            import subprocess
+            result = subprocess.run(
+                ["security", "find-generic-password",
+                 "-s", "Claude Code-credentials", "-w"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                creds = json.loads(result.stdout.strip())
+                return creds["claudeAiOauth"]["accessToken"]
+        except Exception:
+            pass
+
+    return None
+
+
 def fetch_rate_limits(claude_dir: str) -> dict:
     """Fetch rate limit data from Anthropic API using OAuth credentials.
 
     Makes a minimal API call (1 token to haiku) and reads rate limit headers.
     Uses urllib to keep credentials in-process (not exposed via /proc/cmdline).
     """
-    creds_path = os.path.join(claude_dir, ".credentials.json")
-    if not os.path.isfile(creds_path):
+    token = _load_credentials(claude_dir)
+    if not token:
         return {"error": "No credentials found"}
-
-    try:
-        with open(creds_path) as f:
-            creds = json.load(f)
-        token = creds["claudeAiOauth"]["accessToken"]
-    except (json.JSONDecodeError, KeyError):
-        return {"error": "Invalid credentials file"}
 
     body = json.dumps({
         "model": "claude-haiku-4-5-20251001",

--- a/claude_usage/overlay_macos.py
+++ b/claude_usage/overlay_macos.py
@@ -1,0 +1,339 @@
+"""OSD overlay for macOS — always-on-top transparent widget in top-right corner."""
+
+from datetime import datetime
+
+import objc
+from AppKit import (
+    NSView, NSWindow,
+    NSBackingStoreBuffered,
+    NSColor, NSBezierPath, NSFont,
+    NSFontAttributeName, NSForegroundColorAttributeName,
+    NSAttributedString,
+    NSScreen,
+    NSFloatingWindowLevel,
+    NSViewWidthSizable, NSViewHeightSizable,
+    NSEvent,
+)
+from Foundation import NSMakeRect, NSMakePoint
+
+from claude_usage.collector import UsageStats
+
+try:
+    from AppKit import NSWindowStyleMaskBorderless as _BORDERLESS
+except ImportError:
+    from AppKit import NSBorderlessWindowMask as _BORDERLESS  # type: ignore
+
+try:
+    from AppKit import (
+        NSWindowCollectionBehaviorCanJoinAllSpaces,
+        NSWindowCollectionBehaviorStationary,
+        NSWindowCollectionBehaviorIgnoresCycle,
+    )
+    _COLLECTION = (
+        NSWindowCollectionBehaviorCanJoinAllSpaces
+        | NSWindowCollectionBehaviorStationary
+        | NSWindowCollectionBehaviorIgnoresCycle
+    )
+except ImportError:
+    _COLLECTION = 0
+
+
+# Base OSD dimensions (at scale=1.0)
+BASE_WIDTH = 260
+BASE_HEIGHT = 100
+OSD_MARGIN = 16
+OSD_RADIUS = 12
+OSD_BAR_HEIGHT = 6
+OSD_BAR_RADIUS = 3
+MINIMIZED_HEIGHT = 6
+
+SCALE_MIN, SCALE_MAX, SCALE_STEP = 0.6, 2.0, 0.1
+
+# Colors (r, g, b, a)
+BG_RGBA        = (0.08, 0.08, 0.15, 0.75)
+BAR_TRACK_RGBA = (0.25, 0.25, 0.32, 0.60)
+TEXT_RGBA      = (0.88, 0.88, 0.92, 0.95)
+DIM_RGBA       = (0.50, 0.50, 0.58, 0.75)
+WARN_RGBA      = (0.92, 0.70, 0.05, 0.95)
+CRIT_RGBA      = (0.94, 0.27, 0.27, 0.95)
+BAR_BLUE_RGBA  = (0.36, 0.61, 0.84, 0.95)
+
+
+def _bar_color(pct):
+    if pct < 0.6:
+        return BAR_BLUE_RGBA
+    if pct < 0.85:
+        return WARN_RGBA
+    return CRIT_RGBA
+
+
+def _ns_color(r, g, b, a=1.0):
+    return NSColor.colorWithCalibratedRed_green_blue_alpha_(r, g, b, a)
+
+
+def _fill_rrect(x, y, w, h, r):
+    """Fill a rounded rectangle."""
+    r = min(r, w / 2, h / 2)
+    if r < 0.5:
+        NSBezierPath.fillRect_(NSMakeRect(x, y, w, h))
+        return
+    NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
+        NSMakeRect(x, y, w, h), r, r
+    ).fill()
+
+
+def _mono_font(size):
+    try:
+        return NSFont.monospacedSystemFontOfSize_weight_(size, 0.0)
+    except AttributeError:
+        return NSFont.fontWithName_size_("Menlo", size) or NSFont.systemFontOfSize_(size)
+
+
+def _format_reset_short(reset_ts):
+    if reset_ts <= 0:
+        return ""
+    remaining = int(reset_ts - datetime.now().timestamp())
+    if remaining <= 0:
+        return "soon"
+    hours, rem = divmod(remaining, 3600)
+    minutes = rem // 60
+    if hours < 24:
+        return f"{hours}h {minutes}m" if hours > 0 else f"{minutes}m"
+    return datetime.fromtimestamp(reset_ts).strftime("%a %H:%M")
+
+
+def _resize_window(win, scale, minimized):
+    """Resize the window keeping the top-right corner anchored."""
+    frame = win.frame()
+    tr_x = frame.origin.x + frame.size.width
+    tr_y = frame.origin.y + frame.size.height
+    new_w = int(BASE_WIDTH * scale)
+    new_h = MINIMIZED_HEIGHT if minimized else int(BASE_HEIGHT * scale)
+    win.setFrame_display_animate_(
+        NSMakeRect(tr_x - new_w, tr_y - new_h, new_w, new_h),
+        True, False,
+    )
+
+
+class OSDView(NSView):
+    """NSView subclass that renders the OSD overlay via AppKit drawing."""
+
+    def initWithFrame_(self, frame):
+        self = objc.super(OSDView, self).initWithFrame_(frame)
+        if self is None:
+            return None
+        self._session_pct = 0.0
+        self._weekly_pct = 0.0
+        self._session_reset = 0
+        self._weekly_reset = 0
+        self._minimized = False
+        self._scale = 1.0
+        self._opacity = 0.75
+        self._drag_start_screen = None
+        self._drag_start_win = None
+        return self
+
+    def isFlipped(self):
+        return True  # top-left origin — matches Cairo coordinate space
+
+    def acceptsFirstMouse_(self, event):
+        return True
+
+    # ------------------------------------------------------------------ drawing
+
+    @objc.python_method
+    def _draw_str(self, text, x, y, size, rgba):
+        """Draw text; returns drawn width."""
+        font = _mono_font(size)
+        ns_str = NSAttributedString.alloc().initWithString_attributes_(
+            text,
+            {NSFontAttributeName: font,
+             NSForegroundColorAttributeName: _ns_color(*rgba)},
+        )
+        ns_str.drawAtPoint_(NSMakePoint(x, y))
+        return ns_str.size().width
+
+    @objc.python_method
+    def _str_w(self, text, size):
+        ns_str = NSAttributedString.alloc().initWithString_attributes_(
+            text, {NSFontAttributeName: _mono_font(size)}
+        )
+        return ns_str.size().width
+
+    @objc.python_method
+    def _font_h(self, size):
+        return _mono_font(size).boundingRectForFont().size.height
+
+    def drawRect_(self, rect):
+        w = self.bounds().size.width
+        s = self._scale
+
+        # Always clear to transparent first
+        NSColor.clearColor().setFill()
+        NSBezierPath.fillRect_(self.bounds())
+
+        if self._minimized:
+            _ns_color(*BAR_TRACK_RGBA).setFill()
+            _fill_rrect(0, 0, w, MINIMIZED_HEIGHT, 3)
+            if self._session_pct > 0:
+                fw = max(w * min(self._session_pct, 1.0), 4)
+                _ns_color(*_bar_color(self._session_pct)).setFill()
+                _fill_rrect(0, 0, fw, MINIMIZED_HEIGHT, 3)
+            return
+
+        # Background
+        _ns_color(BG_RGBA[0], BG_RGBA[1], BG_RGBA[2], self._opacity).setFill()
+        _fill_rrect(0, 0, w, self.bounds().size.height, OSD_RADIUS * s)
+
+        pad_x = 14 * s
+        pad_y = 10 * s
+        bar_h = OSD_BAR_HEIGHT * s
+        bar_r = OSD_BAR_RADIUS * s
+        bar_w = w - 2 * pad_x
+        fl = 10 * s    # label font size
+        fs = 7.5 * s   # small font size
+        ft = 8 * s     # title font size
+        lh = self._font_h(fl)
+        th = self._font_h(ft)
+
+        # Title
+        self._draw_str("CLAUDE", pad_x, pad_y, ft, DIM_RGBA)
+
+        # --- Session row ---
+        y = pad_y + th + 4 * s
+        pct_s = f"{int(self._session_pct * 100)}%"
+        pct_w = self._str_w(pct_s, fl)
+        self._draw_str("Session", pad_x, y, fl, TEXT_RGBA)
+        self._draw_str(pct_s, w - pad_x - pct_w, y, fl, TEXT_RGBA)
+        reset_s = _format_reset_short(self._session_reset)
+        if reset_s:
+            rw = self._str_w(reset_s, fs)
+            sh = self._font_h(fs)
+            self._draw_str(reset_s, w - pad_x - pct_w - 8 * s - rw,
+                           y + (lh - sh) / 2, fs, DIM_RGBA)
+
+        bar_y = y + lh + 3 * s
+        _ns_color(*BAR_TRACK_RGBA).setFill()
+        _fill_rrect(pad_x, bar_y, bar_w, bar_h, bar_r)
+        if self._session_pct > 0:
+            _ns_color(*_bar_color(self._session_pct)).setFill()
+            _fill_rrect(pad_x, bar_y, max(bar_w * min(self._session_pct, 1.0), bar_h), bar_h, bar_r)
+
+        # --- Weekly row ---
+        y2 = bar_y + bar_h + 10 * s
+        pct_w2 = self._str_w(f"{int(self._weekly_pct * 100)}%", fl)
+        pct_s2 = f"{int(self._weekly_pct * 100)}%"
+        self._draw_str("Weekly", pad_x, y2, fl, TEXT_RGBA)
+        self._draw_str(pct_s2, w - pad_x - pct_w2, y2, fl, TEXT_RGBA)
+        reset_w2 = _format_reset_short(self._weekly_reset)
+        if reset_w2:
+            rw = self._str_w(reset_w2, fs)
+            sh = self._font_h(fs)
+            self._draw_str(reset_w2, w - pad_x - pct_w2 - 8 * s - rw,
+                           y2 + (lh - sh) / 2, fs, DIM_RGBA)
+
+        bar_y2 = y2 + lh + 3 * s
+        _ns_color(*BAR_TRACK_RGBA).setFill()
+        _fill_rrect(pad_x, bar_y2, bar_w, bar_h, bar_r)
+        if self._weekly_pct > 0:
+            _ns_color(*_bar_color(self._weekly_pct)).setFill()
+            _fill_rrect(pad_x, bar_y2, max(bar_w * min(self._weekly_pct, 1.0), bar_h), bar_h, bar_r)
+
+    # ------------------------------------------------------------------ events
+
+    def mouseDown_(self, event):
+        loc = NSEvent.mouseLocation()
+        self._drag_start_screen = (loc.x, loc.y)
+        win = self.window()
+        if win:
+            origin = win.frame().origin
+            self._drag_start_win = (origin.x, origin.y)
+
+    def mouseUp_(self, event):
+        self._drag_start_screen = None
+        self._drag_start_win = None
+
+    def mouseDragged_(self, event):
+        if not self._drag_start_screen or not self._drag_start_win:
+            return
+        loc = NSEvent.mouseLocation()
+        dx = loc.x - self._drag_start_screen[0]
+        dy = loc.y - self._drag_start_screen[1]
+        win = self.window()
+        if win:
+            win.setFrameOrigin_(NSMakePoint(
+                self._drag_start_win[0] + dx,
+                self._drag_start_win[1] + dy,
+            ))
+
+    def rightMouseDown_(self, event):
+        self._minimized = not self._minimized
+        win = self.window()
+        if win:
+            _resize_window(win, self._scale, self._minimized)
+        self.setNeedsDisplay_(True)
+
+    def scrollWheel_(self, event):
+        if self._minimized:
+            return
+        delta = event.deltaY()
+        direction = 1 if delta > 0 else (-1 if delta < 0 else 0)
+        if not direction:
+            return
+        self._scale = max(SCALE_MIN, min(SCALE_MAX, self._scale + direction * SCALE_STEP))
+        win = self.window()
+        if win:
+            _resize_window(win, self._scale, self._minimized)
+        self.setNeedsDisplay_(True)
+
+
+class UsageOverlay:
+    """Manages the macOS borderless floating OSD window."""
+
+    def __init__(self, config=None):
+        cfg = config or {}
+        scale = cfg.get("osd_scale", 1.0)
+        opacity = cfg.get("osd_opacity", 0.75)
+
+        w = int(BASE_WIDTH * scale)
+        h = int(BASE_HEIGHT * scale)
+
+        # Position: top-right of main screen visible area
+        sv = NSScreen.mainScreen().visibleFrame()
+        x = sv.origin.x + sv.size.width - w - OSD_MARGIN
+        y = sv.origin.y + sv.size.height - h - OSD_MARGIN
+
+        self._win = NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
+            NSMakeRect(x, y, w, h), _BORDERLESS, NSBackingStoreBuffered, False
+        )
+        self._win.setOpaque_(False)
+        self._win.setBackgroundColor_(NSColor.clearColor())
+        self._win.setLevel_(NSFloatingWindowLevel + 1)
+        if _COLLECTION:
+            self._win.setCollectionBehavior_(_COLLECTION)
+        self._win.setIgnoresMouseEvents_(False)
+        self._win.setHasShadow_(False)
+        self._win.setAcceptsMouseMovedEvents_(True)
+
+        self._view = OSDView.alloc().initWithFrame_(NSMakeRect(0, 0, w, h))
+        self._view._scale = scale
+        self._view._opacity = opacity
+        self._view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
+        self._win.setContentView_(self._view)
+
+    def show_all(self):
+        self._win.orderFront_(None)
+
+    def hide(self):
+        self._win.orderOut_(None)
+
+    def set_opacity(self, value: float):
+        self._view._opacity = max(0.15, min(1.0, value))
+        self._view.setNeedsDisplay_(True)
+
+    def update(self, stats: UsageStats):
+        self._view._session_pct = stats.session_utilization
+        self._view._weekly_pct = stats.weekly_utilization
+        self._view._session_reset = stats.session_reset
+        self._view._weekly_reset = stats.weekly_reset
+        self._view.setNeedsDisplay_(True)

--- a/claude_usage/widget_macos.py
+++ b/claude_usage/widget_macos.py
@@ -1,0 +1,443 @@
+"""macOS menu bar app and detailed popup window."""
+
+import os
+import queue
+import threading
+from datetime import datetime
+
+import objc
+import rumps
+from AppKit import (
+    NSWindow, NSView, NSObject,
+    NSBackingStoreBuffered,
+    NSColor, NSBezierPath, NSFont,
+    NSFontAttributeName, NSForegroundColorAttributeName,
+    NSAttributedString,
+    NSScreen,
+    NSApp,
+    NSViewWidthSizable, NSViewHeightSizable,
+)
+from Foundation import NSMakeRect, NSMakePoint
+
+try:
+    from AppKit import (
+        NSWindowStyleMaskTitled,
+        NSWindowStyleMaskClosable,
+    )
+    _POPUP_MASK = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
+except ImportError:
+    _POPUP_MASK = 1 | 2  # NSWindowStyleMaskTitled | NSWindowStyleMaskClosable
+
+try:
+    from AppKit import NSAppearance
+    _DARK_APPEARANCE = NSAppearance.appearanceNamed_("NSAppearanceNameDarkAqua")
+except Exception:
+    _DARK_APPEARANCE = None
+
+from claude_usage.collector import collect_all, UsageStats
+from claude_usage.overlay_macos import UsageOverlay
+
+ICON_PATH = os.path.join(os.path.dirname(__file__), "icons", "claude-tray.svg")
+
+# Popup colors (r, g, b, a)
+_BG    = (0.102, 0.102, 0.180, 1.0)
+_PRI   = (0.878, 0.878, 0.910, 1.0)
+_SEC   = (0.541, 0.541, 0.604, 1.0)
+_DIM   = (0.333, 0.333, 0.408, 1.0)
+_LINK  = (0.420, 0.643, 0.851, 1.0)
+_BAR   = (0.357, 0.608, 0.835, 1.0)
+_TRACK = (0.200, 0.200, 0.251, 1.0)
+_SEP   = (0.165, 0.165, 0.220, 1.0)
+_ERR   = (0.937, 0.267, 0.267, 1.0)
+
+PAD_X = 24
+PAD_TOP = 20
+PAD_BTM = 20
+POPUP_W = 520
+
+
+def _ns_color(r, g, b, a=1.0):
+    return NSColor.colorWithCalibratedRed_green_blue_alpha_(r, g, b, a)
+
+
+def _fill_rrect(x, y, w, h, r=6.0):
+    r = min(r, w / 2, h / 2)
+    if r < 0.5:
+        NSBezierPath.fillRect_(NSMakeRect(x, y, w, h))
+        return
+    NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
+        NSMakeRect(x, y, w, h), r, r
+    ).fill()
+
+
+def _sys_font(size, bold=False):
+    if bold:
+        return NSFont.boldSystemFontOfSize_(size)
+    return NSFont.systemFontOfSize_(size)
+
+
+def _draw_str(text, x, y, font, rgba):
+    """Draw text at (x, y) — with isFlipped=True, y=0 is top."""
+    ns_str = NSAttributedString.alloc().initWithString_attributes_(
+        text, {NSFontAttributeName: font,
+               NSForegroundColorAttributeName: _ns_color(*rgba)}
+    )
+    ns_str.drawAtPoint_(NSMakePoint(x, y))
+    return ns_str.size()
+
+
+def _str_size(text, font):
+    ns_str = NSAttributedString.alloc().initWithString_attributes_(
+        text, {NSFontAttributeName: font}
+    )
+    return ns_str.size()
+
+
+def _format_reset_duration(reset_ts):
+    if reset_ts <= 0:
+        return ""
+    remaining = int(reset_ts - datetime.now().timestamp())
+    if remaining <= 0:
+        return "Resets soon"
+    hours, rem = divmod(remaining, 3600)
+    minutes = rem // 60
+    return f"Resets in {hours} hr {minutes} min" if hours > 0 else f"Resets in {minutes} min"
+
+
+def _format_reset_day(reset_ts):
+    if reset_ts <= 0:
+        return ""
+    return datetime.fromtimestamp(reset_ts).strftime("Resets %a %I:%M %p")
+
+
+def _format_session_duration(seconds):
+    hours, rem = divmod(int(seconds), 3600)
+    minutes = rem // 60
+    return f"{hours}h {minutes}m" if hours > 0 else f"{minutes}m"
+
+
+def _calc_popup_height(n_sessions):
+    """Calculate the needed popup content height."""
+    y = PAD_TOP
+    y += 26   # "Plan usage limits" header
+    y += 12   # header bottom margin
+    y += 52   # usage row (label + bar)
+    y += 25   # separator
+    y += 26   # "Weekly limits" header
+    y += 12
+    y += 52   # usage row
+    y += 25   # separator
+    y += 26   # "Active sessions" header
+    y += 12
+    rows = max(1, min(n_sessions, 8))  # at least "No active sessions"
+    y += rows * 24
+    y += 25   # separator
+    y += 22   # footer
+    y += PAD_BTM
+    return y
+
+
+class PopupView(NSView):
+    """Custom-drawn content view for the details popup."""
+
+    def initWithFrame_(self, frame):
+        self = objc.super(PopupView, self).initWithFrame_(frame)
+        if self is None:
+            return None
+        self._stats = None
+        return self
+
+    def isFlipped(self):
+        return True
+
+    def drawRect_(self, rect):
+        w = self.bounds().size.width
+
+        # Dark background
+        _ns_color(*_BG).setFill()
+        NSBezierPath.fillRect_(self.bounds())
+
+        if self._stats is None:
+            return
+
+        stats = self._stats
+        bar_w = 200
+        y = PAD_TOP
+
+        # ---- Plan usage limits ----
+        y = self._section_header("Plan usage limits", y, w)
+        y = self._usage_row(
+            "Current session",
+            _format_reset_duration(stats.session_reset),
+            stats.session_utilization,
+            y, w, bar_w,
+        )
+        y = self._draw_separator(y)
+
+        # ---- Weekly limits ----
+        y = self._section_header("Weekly limits", y, w)
+        y = self._usage_row(
+            "All models",
+            _format_reset_day(stats.weekly_reset),
+            stats.weekly_utilization,
+            y, w, bar_w,
+        )
+        y = self._draw_separator(y)
+
+        # ---- Active sessions ----
+        n = len(stats.active_sessions)
+        y = self._section_header("Active sessions", y, w,
+                                  right_text=f"{n} running")
+        if stats.active_sessions:
+            for sess in stats.active_sessions[:8]:
+                y = self._session_row(sess, y, w)
+        else:
+            f = _sys_font(11)
+            _draw_str("No active sessions", PAD_X, y, f, _DIM)
+            y += _str_size("X", f).height + 8
+
+        y = self._draw_separator(y)
+
+        # ---- Footer ----
+        f_upd = _sys_font(11)
+        _draw_str("Last updated: just now", PAD_X, y, f_upd, _DIM)
+        if stats.rate_limit_error:
+            err_text = f"API: {stats.rate_limit_error}"
+            sz = _str_size(err_text, f_upd)
+            _draw_str(err_text, w - PAD_X - sz.width, y, f_upd, _ERR)
+
+    # ------------------------------------------------------------------ helpers
+
+    @objc.python_method
+    def _section_header(self, title, y, w, right_text=""):
+        f_title = _sys_font(14, bold=True)
+        _draw_str(title, PAD_X, y, f_title, _PRI)
+        if right_text:
+            f_right = _sys_font(12)
+            sz = _str_size(right_text, f_right)
+            _draw_str(right_text, w - PAD_X - sz.width,
+                      y + (_str_size(title, f_title).height - sz.height) / 2,
+                      f_right, _SEC)
+        return y + _str_size(title, f_title).height + 12
+
+    @objc.python_method
+    def _usage_row(self, label, subtitle, fraction, y, w, bar_w):
+        f_name = _sys_font(13, bold=True)
+        f_sub  = _sys_font(11)
+        f_pct  = _sys_font(12)
+
+        label_h = _str_size(label, f_name).height
+        sub_h   = _str_size("X", f_sub).height if subtitle else 0
+        pct_h   = _str_size("X", f_pct).height
+        row_h   = label_h + (sub_h + 2 if subtitle else 0)
+
+        left_w = 140
+        # Name label
+        _draw_str(label, PAD_X, y, f_name, _PRI)
+        if subtitle:
+            _draw_str(subtitle, PAD_X, y + label_h + 2, f_sub, _SEC)
+
+        # Bar (center-aligned vertically in row)
+        bar_x = PAD_X + left_w
+        bar_h = 12
+        bar_y = y + (row_h - bar_h) / 2
+        _ns_color(*_TRACK).setFill()
+        _fill_rrect(bar_x, bar_y, bar_w, bar_h, 6)
+        if fraction > 0:
+            fill_w = max(bar_w * min(fraction, 1.0), bar_h)
+            _ns_color(*_BAR).setFill()
+            _fill_rrect(bar_x, bar_y, fill_w, bar_h, 6)
+
+        # Percentage label (right-aligned)
+        pct_text = f"{int(fraction * 100)}% used"
+        pct_sz = _str_size(pct_text, f_pct)
+        _draw_str(pct_text, w - PAD_X - pct_sz.width,
+                  y + (row_h - pct_h) / 2, f_pct, _SEC)
+
+        return y + row_h + 16
+
+    @objc.python_method
+    def _draw_separator(self, y):
+        _ns_color(*_SEP).setFill()
+        NSBezierPath.fillRect_(NSMakeRect(PAD_X, y + 4, POPUP_W - 2 * PAD_X, 1))
+        return y + 25
+
+    @objc.python_method
+    def _session_row(self, sess, y, w):
+        f = _sys_font(11)
+        started = datetime.fromtimestamp(sess.get("startedAt", 0) / 1000)
+        duration = datetime.now() - started
+        cwd = sess.get("cwd", "?").replace(os.path.expanduser("~"), "~")
+
+        dur_text = _format_session_duration(int(duration.total_seconds()))
+        dur_sz = _str_size(dur_text, f)
+        _draw_str(dur_text, w - PAD_X - dur_sz.width, y, f, _DIM)
+
+        # Truncate cwd to fit
+        max_cwd_w = w - 2 * PAD_X - dur_sz.width - 16
+        while cwd and _str_size(cwd, f).width > max_cwd_w and len(cwd) > 3:
+            cwd = "…" + cwd[max(1, len(cwd) - 30):]
+
+        _draw_str(cwd, PAD_X, y, f, _LINK)
+        return y + _str_size("X", f).height + 8
+
+
+class _PopupDelegate(NSObject):
+    """Window delegate that hides instead of closing."""
+    def windowShouldClose_(self, sender):
+        sender.orderOut_(None)
+        return False
+
+
+class UsagePopup:
+    """Detailed stats popup window."""
+
+    def __init__(self):
+        h = _calc_popup_height(0)
+        sv = NSScreen.mainScreen().visibleFrame()
+        x = sv.origin.x + (sv.size.width - POPUP_W) / 2
+        y = sv.origin.y + (sv.size.height - h) / 2
+
+        self._win = NSWindow.alloc().initWithContentRect_styleMask_backing_defer_(
+            NSMakeRect(x, y, POPUP_W, h), _POPUP_MASK, NSBackingStoreBuffered, False
+        )
+        self._win.setTitle_("Claude Usage")
+        if _DARK_APPEARANCE:
+            self._win.setAppearance_(_DARK_APPEARANCE)
+        self._win.setMinSize_(NSMakePoint(POPUP_W, 300))
+
+        self._delegate = _PopupDelegate.alloc().init()
+        self._win.setDelegate_(self._delegate)
+
+        self._view = PopupView.alloc().initWithFrame_(NSMakeRect(0, 0, POPUP_W, h))
+        self._view.setAutoresizingMask_(NSViewWidthSizable | NSViewHeightSizable)
+        self._win.setContentView_(self._view)
+
+    def update(self, stats: UsageStats):
+        self._view._stats = stats
+        # Resize window to fit content
+        n = len(stats.active_sessions)
+        new_h = _calc_popup_height(n)
+        frame = self._win.frame()
+        # Keep top edge fixed (macOS origin is bottom-left)
+        top_y = frame.origin.y + frame.size.height
+        self._win.setFrame_display_(
+            NSMakeRect(frame.origin.x, top_y - new_h, POPUP_W, new_h), True
+        )
+        self._view.setNeedsDisplay_(True)
+
+    def show(self):
+        NSApp.activateIgnoringOtherApps_(True)
+        self._win.makeKeyAndOrderFront_(None)
+
+    def hide(self):
+        self._win.orderOut_(None)
+
+
+class ClaudeUsageTray(rumps.App):
+    """Menu bar application."""
+
+    def __init__(self, config: dict):
+        # Try SVG icon; fall back gracefully if unsupported
+        icon = ICON_PATH if os.path.isfile(ICON_PATH) else None
+        super().__init__(
+            name="Claude Usage",
+            icon=icon,
+            template=True,
+            quit_button=None,
+        )
+        self.config = config
+        self.stats = UsageStats()
+        self._update_queue: queue.Queue = queue.Queue()
+
+        # Menu items
+        self.mi_session = rumps.MenuItem("Session: —")
+        self.mi_week    = rumps.MenuItem("Weekly: —")
+        self.mi_details = rumps.MenuItem("Details…",    callback=self._on_show_details)
+        self.mi_refresh = rumps.MenuItem("Refresh",     callback=self._on_refresh)
+        self.mi_osd     = rumps.MenuItem("OSD Overlay", callback=self._on_toggle_osd)
+        self.mi_osd.state = 1  # checked
+
+        opacity_menu = rumps.MenuItem("OSD Opacity")
+        for pct in [100, 75, 50, 25]:
+            mi = rumps.MenuItem(f"{pct}%",
+                                callback=lambda s, p=pct: self._on_set_opacity(p))
+            opacity_menu.add(mi)
+
+        mi_quit = rumps.MenuItem("Quit", callback=self._on_quit)
+
+        self.menu = [
+            self.mi_session,
+            self.mi_week,
+            None,
+            self.mi_details,
+            self.mi_refresh,
+            None,
+            self.mi_osd,
+            opacity_menu,
+            None,
+            mi_quit,
+        ]
+
+        self.popup  = UsagePopup()
+        self.overlay = UsageOverlay(config)
+        self.overlay.show_all()
+
+        # Kick off the first refresh
+        self._do_refresh()
+
+    # ------------------------------------------------------------------ timers
+
+    @rumps.timer(1)
+    def _check_queue(self, _):
+        """Drain the update queue on the main thread."""
+        try:
+            stats = self._update_queue.get_nowait()
+            self._apply_stats(stats)
+        except queue.Empty:
+            pass
+
+    @rumps.timer(30)  # secondary auto-refresh fallback
+    def _auto_refresh(self, _):
+        self._do_refresh()
+
+    # ------------------------------------------------------------------ actions
+
+    def _do_refresh(self):
+        """Launch background data collection."""
+        threading.Thread(target=self._collect_worker, daemon=True).start()
+
+    def _collect_worker(self):
+        stats = collect_all(self.config)
+        self._update_queue.put(stats)
+
+    def _apply_stats(self, stats: UsageStats):
+        self.stats = stats
+        s_pct = int(stats.session_utilization * 100)
+        w_pct = int(stats.weekly_utilization * 100)
+
+        self.mi_session.title = f"Session: {s_pct}% used"
+        self.mi_week.title    = f"Weekly: {w_pct}% used"
+        self.title = f"{s_pct}%"
+
+        self.popup.update(stats)
+        self.overlay.update(stats)
+
+    def _on_show_details(self, _):
+        self.popup.show()
+
+    def _on_refresh(self, _):
+        self._do_refresh()
+
+    def _on_toggle_osd(self, sender):
+        sender.state = not sender.state
+        if sender.state:
+            self.overlay.show_all()
+        else:
+            self.overlay.hide()
+
+    def _on_set_opacity(self, pct):
+        self.overlay.set_opacity(pct / 100.0)
+
+    def _on_quit(self, _):
+        rumps.quit_application()

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Install Claude Usage Widget as a macOS Launch Agent (autostart on login).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+PLIST_FILE="$PLIST_DIR/com.claude-usage-widget.plist"
+PYTHON="$(which python3)"
+
+echo "=== Claude Usage Widget — macOS installer ==="
+
+# Install Python dependencies
+echo "Installing Python dependencies..."
+pip3 install -q -r "$SCRIPT_DIR/requirements-macos.txt"
+
+# Create LaunchAgents dir if missing
+mkdir -p "$PLIST_DIR"
+
+# Write the plist
+cat > "$PLIST_FILE" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-usage-widget</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>$PYTHON</string>
+        <string>$SCRIPT_DIR/main.py</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>$HOME/Library/Logs/claude-usage-widget.log</string>
+    <key>StandardErrorPath</key>
+    <string>$HOME/Library/Logs/claude-usage-widget.err</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>
+EOF
+
+# Load the agent
+launchctl unload "$PLIST_FILE" 2>/dev/null || true
+launchctl load "$PLIST_FILE"
+
+echo ""
+echo "Done! The widget will start automatically on next login."
+echo "To start it now: launchctl start com.claude-usage-widget"
+echo "To remove:       launchctl unload $PLIST_FILE && rm $PLIST_FILE"

--- a/main.py
+++ b/main.py
@@ -5,12 +5,27 @@ import os
 import signal
 import sys
 
-# Force XWayland for reliable borderless windows on Wayland compositors.
-os.environ.setdefault("GDK_BACKEND", "x11")
+_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_PATH = os.path.join(_BASE_DIR, "config.json")
+if not os.path.isfile(CONFIG_PATH):
+    CONFIG_PATH = os.path.join(_BASE_DIR, "config.json.example")
 
-# Ensure gi-cairo is available (needed for transparent OSD overlay).
-# python3-gi-cairo must be installed; print a clear message if missing.
-def _check_gi_cairo():
+
+def _main_macos():
+    """macOS entry point: uses AppKit/rumps."""
+    from claude_usage.config import load_config
+    from claude_usage.widget_macos import ClaudeUsageTray
+
+    config = load_config(CONFIG_PATH)
+    app = ClaudeUsageTray(config)
+    app.run()
+
+
+def _main_linux():
+    """Linux entry point: uses GTK3/AppIndicator."""
+    # Force XWayland for reliable borderless windows on Wayland compositors.
+    os.environ.setdefault("GDK_BACKEND", "x11")
+
     try:
         import gi
         gi.require_foreign("cairo")
@@ -25,28 +40,27 @@ def _check_gi_cairo():
         )
         sys.exit(1)
 
-_check_gi_cairo()
+    import gi
+    gi.require_version("Gtk", "3.0")
+    from gi.repository import Gtk
+    from claude_usage.config import load_config
+    from claude_usage.widget import ClaudeUsageTray
 
-import gi
-
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
-
-from claude_usage.config import load_config
-from claude_usage.widget import ClaudeUsageTray
-
-_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-CONFIG_PATH = os.path.join(_BASE_DIR, "config.json")
-if not os.path.isfile(CONFIG_PATH):
-    CONFIG_PATH = os.path.join(_BASE_DIR, "config.json.example")
+    config = load_config(CONFIG_PATH)
+    _tray = ClaudeUsageTray(config)
+    Gtk.main()
 
 
 def main():
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    config = load_config(CONFIG_PATH)
-    tray = ClaudeUsageTray(config)
-    Gtk.main()
+    if sys.platform == "darwin":
+        _main_macos()
+    elif sys.platform.startswith("linux"):
+        _main_linux()
+    else:
+        print(f"ERROR: Unsupported platform: {sys.platform}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/requirements-macos.txt
+++ b/requirements-macos.txt
@@ -1,0 +1,2 @@
+rumps>=0.4.0
+pyobjc-framework-Cocoa>=9.0


### PR DESCRIPTION
## Summary

- Replaces GTK3 + AyatanaAppIndicator3 with native macOS APIs using `pyobjc` and `rumps`
- OSD overlay: borderless transparent `NSWindow`/`NSView` with equivalent drawing to the Cairo version (drag, scroll-to-resize, right-click minimize all preserved)
- Menu bar: `rumps`-based `NSStatusBar` app with the same menu structure as the Linux version
- Detail popup: custom-drawn `NSWindow` with dark appearance
- `collector.py`: added macOS Keychain fallback — Claude Code stores OAuth credentials in Keychain (not `.credentials.json`) on macOS
- `main.py`: platform detection routes `darwin` → AppKit stack, `linux` → GTK stack; Linux behavior is unchanged

## New files

| File | Purpose |
|------|---------|
| `claude_usage/overlay_macos.py` | OSD overlay (NSWindow + NSView) |
| `claude_usage/widget_macos.py` | Menu bar app (rumps) + popup window |
| `requirements-macos.txt` | `rumps>=0.4.0`, `pyobjc-framework-Cocoa>=9.0` |
| `install-macos.sh` | Launch Agent installer for login autostart |

## Test plan

- [ ] `pip3 install rumps pyobjc-framework-Cocoa`
- [ ] `python3 main.py` — OSD overlay appears top-right, menu bar item shows session %
- [ ] Menu → Details… — popup shows usage bars and active sessions
- [ ] OSD drag / scroll-to-resize / right-click minimize
- [ ] Menu → OSD Opacity submenu
- [ ] Existing Linux behavior unchanged (all 10 unit tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)