### PR TITLE
Threshold notifications + history sparklines

### DIFF
--- a/claude_usage/collector.py
+++ b/claude_usage/collector.py
@@ -13,6 +13,15 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from claude_usage.history import aggregate, append_sample, load_samples, prune
+
+HISTORY_FILENAME = "usage-history.jsonl"
+HISTORY_KEEP_DAYS = 8
+SESSION_WINDOW_SECONDS = 5 * 3600
+SESSION_BUCKETS = 30
+WEEKLY_WINDOW_SECONDS = 7 * 86400
+WEEKLY_BUCKETS = 28
+
 
 @dataclass
 class UsageStats:
@@ -35,6 +44,8 @@ class UsageStats:
     overage_status: str = ""  # "rejected" or "allowed"
     fallback_status: str = ""  # "available" or ""
     rate_limit_error: str = ""  # error message if API call fails
+    session_history: list = field(default_factory=list)  # bucketed sparkline (oldest first)
+    weekly_history: list = field(default_factory=list)
 
 
 def parse_history(path: str) -> UsageStats:
@@ -454,6 +465,9 @@ def collect_all(config: dict[str, Any]) -> UsageStats:
     stats.active_sessions = get_active_sessions(claude_dir)
 
     rate_limits = fetch_rate_limits(claude_dir)
+    history_path = os.path.join(claude_dir, HISTORY_FILENAME)
+    now_ts = datetime.now().timestamp()
+
     if "error" in rate_limits:
         stats.rate_limit_error = rate_limits["error"]
     else:
@@ -463,5 +477,20 @@ def collect_all(config: dict[str, Any]) -> UsageStats:
         stats.weekly_reset = rate_limits["weekly_reset"]
         stats.overage_status = rate_limits["overage_status"]
         stats.fallback_status = rate_limits["fallback_status"]
+        try:
+            append_sample(history_path, now_ts, stats.session_utilization, stats.weekly_utilization)
+            prune(history_path, keep_seconds=HISTORY_KEEP_DAYS * 86400, now=now_ts)
+        except OSError:
+            pass
+
+    samples = load_samples(history_path, since_ts=now_ts - WEEKLY_WINDOW_SECONDS)
+    stats.session_history = aggregate(
+        samples, "session", now=now_ts,
+        window_seconds=SESSION_WINDOW_SECONDS, n_buckets=SESSION_BUCKETS,
+    )
+    stats.weekly_history = aggregate(
+        samples, "weekly", now=now_ts,
+        window_seconds=WEEKLY_WINDOW_SECONDS, n_buckets=WEEKLY_BUCKETS,
+    )
 
     return stats

--- a/claude_usage/config.py
+++ b/claude_usage/config.py
@@ -47,6 +47,8 @@ DEFAULT_CONFIG: Config = {
     # 1.0 = default size; increase for HiDPI displays where the overlay appears
     # too small, or decrease to make it less intrusive.
     "osd_scale": 1.0,
+    "notifications_enabled": True,
+    "notify_thresholds": [0.75, 0.90],
 }
 
 

--- a/claude_usage/history.py
+++ b/claude_usage/history.py
@@ -1,0 +1,95 @@
+"""Time-series storage for past utilization samples.
+
+Samples are appended to a JSONL file as `{ts, session, weekly}`. The pure
+`aggregate` function turns a point list into fixed-width buckets for sparkline
+rendering; tests cover it directly.
+"""
+
+import json
+import os
+import tempfile
+
+
+def append_sample(path: str, ts: float, session_util: float, weekly_util: float) -> None:
+    """Append one sample to the JSONL history file."""
+    line = json.dumps({
+        "ts": float(ts),
+        "session": float(session_util),
+        "weekly": float(weekly_util),
+    })
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "a") as f:
+        f.write(line + "\n")
+
+
+def load_samples(path: str, since_ts: float = 0.0) -> list[dict]:
+    """Read all samples from JSONL, optionally filtering to `ts >= since_ts`."""
+    if not os.path.isfile(path):
+        return []
+    out = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("ts", 0) >= since_ts:
+                out.append(entry)
+    return out
+
+
+def prune(path: str, keep_seconds: float, now: float) -> int:
+    """Rewrite file dropping samples older than `now - keep_seconds`. Returns kept count."""
+    if not os.path.isfile(path):
+        return 0
+    cutoff = now - keep_seconds
+    kept = load_samples(path, since_ts=cutoff)
+    # Atomic rewrite
+    dirname = os.path.dirname(path) or "."
+    fd, tmp_path = tempfile.mkstemp(dir=dirname, prefix=".history-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            for entry in kept:
+                f.write(json.dumps(entry) + "\n")
+        os.replace(tmp_path, path)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+    return len(kept)
+
+
+def aggregate(
+    points: list[dict],
+    key: str,
+    now: float,
+    window_seconds: float,
+    n_buckets: int,
+) -> list[float]:
+    """Bucket samples into a fixed-width series ending at `now`.
+
+    Each bucket holds the MAX utilization seen in its time slice (utilization
+    is what matters for "did we approach the limit"). Empty buckets become 0.0.
+    Returns a list of length `n_buckets`, oldest first.
+    """
+    if n_buckets <= 0 or window_seconds <= 0:
+        return []
+    bucket_size = window_seconds / n_buckets
+    start = now - window_seconds
+    out = [0.0] * n_buckets
+    for p in points:
+        ts = p.get("ts", 0)
+        if ts < start or ts > now:
+            continue
+        idx = int((ts - start) / bucket_size)
+        if idx >= n_buckets:
+            idx = n_buckets - 1
+        elif idx < 0:
+            idx = 0
+        val = float(p.get(key, 0.0))
+        if val > out[idx]:
+            out[idx] = val
+    return out

--- a/claude_usage/notifier.py
+++ b/claude_usage/notifier.py
@@ -1,0 +1,78 @@
+"""Threshold-crossing notifications for usage utilization.
+
+Pure crossing logic lives in `CrossingDetector` (testable). `UsageNotifier`
+binds the detector to a platform-appropriate desktop notification sender.
+"""
+
+import sys
+
+
+class CrossingDetector:
+    """Detects upward threshold crossings in a stream of values per scope.
+
+    A threshold fires only on the transition that crosses it (prev < t <= cur),
+    so a reset (cur < prev) silently re-arms it for the next cycle.
+    """
+
+    def __init__(self, thresholds):
+        self.thresholds = sorted(t for t in thresholds if 0.0 < t <= 1.0)
+        self._last: dict[str, float] = {}
+
+    def check(self, scope: str, util: float) -> list[float]:
+        prev = self._last.get(scope)
+        self._last[scope] = util
+        if prev is None:
+            return []
+        return [t for t in self.thresholds if prev < t <= util]
+
+
+def _send_linux(title: str, body: str) -> None:
+    try:
+        import gi
+        gi.require_version("Notify", "0.7")
+        from gi.repository import Notify
+        if not Notify.is_initted():
+            Notify.init("Claude Usage")
+        Notify.Notification.new(title, body, "dialog-warning").show()
+    except Exception:
+        pass
+
+
+def _send_macos(title: str, body: str) -> None:
+    try:
+        import rumps
+        rumps.notification(title=title, subtitle="", message=body)
+    except Exception:
+        pass
+
+
+def _default_sender():
+    return _send_macos if sys.platform == "darwin" else _send_linux
+
+
+class UsageNotifier:
+    """Fires desktop notifications when session/weekly utilization crosses a threshold."""
+
+    SCOPES = (
+        ("session", "Session", "session_utilization"),
+        ("weekly", "Weekly", "weekly_utilization"),
+    )
+
+    def __init__(self, config: dict, sender=None):
+        self.enabled = bool(config.get("notifications_enabled", True))
+        thresholds = config.get("notify_thresholds", [0.75, 0.90])
+        self.detector = CrossingDetector(thresholds)
+        self._send = sender or _default_sender()
+
+    def check_stats(self, stats) -> None:
+        if not self.enabled:
+            return
+        for scope, label, attr in self.SCOPES:
+            util = getattr(stats, attr, 0.0) or 0.0
+            for t in self.detector.check(scope, util):
+                pct_t = int(round(t * 100))
+                pct_now = int(round(util * 100))
+                self._send(
+                    f"Claude {label} usage at {pct_now}%",
+                    f"Crossed the {pct_t}% threshold.",
+                )

--- a/claude_usage/widget.py
+++ b/claude_usage/widget.py
@@ -17,6 +17,7 @@ from gi.repository import Gtk, GLib, Gdk, Pango  # type: ignore[attr-defined]
 from gi.repository import AyatanaAppIndicator3 as AppIndicator  # type: ignore[attr-defined]
 
 from claude_usage.collector import collect_all, UsageStats
+from claude_usage.notifier import UsageNotifier
 from claude_usage.overlay import UsageOverlay
 
 if TYPE_CHECKING:
@@ -454,6 +455,7 @@ class ClaudeUsageTray:
         self.popup: UsagePopup = UsagePopup(config)
         self.overlay: UsageOverlay = UsageOverlay(config)
         self.overlay.show_all()
+        self.notifier = UsageNotifier(config)
 
         # Populate the UI immediately, then register the recurring timer.
         self._refresh_async()
@@ -512,6 +514,7 @@ class ClaudeUsageTray:
 
         self.popup.update(stats)
         self.overlay.update(stats)
+        self.notifier.check_stats(stats)
         return False  # remove from idle queue
 
     def _on_timer(self) -> bool:

--- a/claude_usage/widget.py
+++ b/claude_usage/widget.py
@@ -276,6 +276,50 @@ class UsagePopup(Gtk.Window):
 
         self._content_box.pack_start(row, False, False, 0)
 
+    def _add_sparkline(self, buckets: list[float], label: str) -> None:
+        """Append a vertical-bar sparkline with a caption underneath.
+
+        Each bucket is drawn as a thin vertical bar whose height is proportional
+        to its utilization (0.0-1.0). Empty buckets are skipped.
+        """
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        box.set_margin_bottom(12)
+
+        area = Gtk.DrawingArea()
+        area.set_size_request(-1, 32)
+
+        def draw(widget: Gtk.Widget, cr: cairo.Context) -> None:
+            w = widget.get_allocated_width()
+            h = widget.get_allocated_height()
+            r, g, b = _hex_to_rgb(BAR_TRACK)
+            cr.set_source_rgb(r, g, b)
+            _rounded_rect(cr, 0, 0, w, h, 4)
+            cr.fill()
+            if not buckets:
+                return
+            n = len(buckets)
+            gap = 1.0
+            bar_w = max(1.0, (w - (n - 1) * gap) / n)
+            r, g, b = _hex_to_rgb(BAR_BLUE)
+            cr.set_source_rgb(r, g, b)
+            for i, val in enumerate(buckets):
+                if val <= 0:
+                    continue
+                bx = i * (bar_w + gap)
+                bh = max(1.0, h * min(float(val), 1.0))
+                cr.rectangle(bx, h - bh, bar_w, bh)
+            cr.fill()
+
+        area.connect("draw", draw)
+        box.pack_start(area, False, False, 0)
+
+        lbl = Gtk.Label(label=label)
+        lbl.get_style_context().add_class("dim-text")
+        lbl.set_halign(Gtk.Align.START)
+        box.pack_start(lbl, False, False, 0)
+
+        self._content_box.pack_start(box, False, False, 0)
+
     def _add_separator(self) -> None:
         """Append a styled horizontal separator."""
         sep = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
@@ -298,6 +342,7 @@ class UsagePopup(Gtk.Window):
             _format_reset_duration(stats.session_reset),
             stats.session_utilization,
         )
+        self._add_sparkline(stats.session_history, "Last 5 hours")
 
         self._add_separator()
 
@@ -307,6 +352,7 @@ class UsagePopup(Gtk.Window):
             _format_reset_day(stats.weekly_reset),
             stats.weekly_utilization,
         )
+        self._add_sparkline(stats.weekly_history, "Last 7 days")
 
         self._add_separator()
 

--- a/claude_usage/widget_macos.py
+++ b/claude_usage/widget_macos.py
@@ -62,6 +62,7 @@ except Exception:
     _DARK_APPEARANCE = None
 
 from claude_usage.collector import collect_all, UsageStats
+from claude_usage.notifier import UsageNotifier
 from claude_usage.overlay_macos import UsageOverlay
 
 ICON_PATH: str = os.path.join(os.path.dirname(__file__), "icons", "claude-tray.svg")
@@ -743,6 +744,7 @@ class ClaudeUsageTray(rumps.App):
         self.popup  = UsagePopup()
         self.overlay = UsageOverlay(config)
         self.overlay.show_all()
+        self.notifier = UsageNotifier(config)
 
         # Prime the pump: start the first data collection immediately so the
         # tray icon shows real data as soon as the app is ready.
@@ -862,6 +864,7 @@ class ClaudeUsageTray(rumps.App):
 
         self.popup.update(stats)
         self.overlay.update(stats)
+        self.notifier.check_stats(stats)
 
     # ------------------------------------------------------------------
     # Menu item action callbacks

--- a/claude_usage/widget_macos.py
+++ b/claude_usage/widget_macos.py
@@ -194,6 +194,11 @@ def _format_session_duration(seconds: int) -> str:
     return f"{hours}h {minutes}m" if hours > 0 else f"{minutes}m"
 
 
+SPARK_H = 32
+SPARK_LABEL_H = 14
+SPARK_BLOCK_H = SPARK_H + SPARK_LABEL_H + 8  # bar + caption + bottom margin
+
+
 def _calc_popup_height(n_sessions: int) -> int:
     """Compute the total pixel height required for the popup content.
 
@@ -203,9 +208,9 @@ def _calc_popup_height(n_sessions: int) -> int:
 
     Sections (top to bottom):
       - PAD_TOP
-      - "Plan usage limits" header + usage row
+      - "Plan usage limits" header + usage row + sparkline
       - separator
-      - "Weekly limits" header + usage row
+      - "Weekly limits" header + usage row + sparkline
       - separator
       - "Active sessions" header + session rows (1-8, or placeholder)
       - separator
@@ -216,10 +221,12 @@ def _calc_popup_height(n_sessions: int) -> int:
     y += 26   # "Plan usage limits" header text height
     y += 12   # spacing below header
     y += 52   # usage row: label + progress bar (label_h + bar area + bottom margin)
+    y += SPARK_BLOCK_H  # session sparkline
     y += 25   # separator (1 px line + surrounding padding)
     y += 26   # "Weekly limits" header
     y += 12
     y += 52   # usage row
+    y += SPARK_BLOCK_H  # weekly sparkline
     y += 25   # separator
     y += 26   # "Active sessions" header
     y += 12
@@ -303,6 +310,8 @@ class PopupView(NSView):
             stats.session_utilization,
             y, w, bar_w,
         )
+        y = self._sparkline(stats.session_history, "Last 5 hours",
+                            PAD_X, y, w - 2 * PAD_X)
         y = self._draw_separator(y)
 
         # ---- Section 2: Weekly limits ----
@@ -313,6 +322,8 @@ class PopupView(NSView):
             stats.weekly_utilization,
             y, w, bar_w,
         )
+        y = self._sparkline(stats.weekly_history, "Last 7 days",
+                            PAD_X, y, w - 2 * PAD_X)
         y = self._draw_separator(y)
 
         # ---- Section 3: Active sessions ----
@@ -449,6 +460,42 @@ class PopupView(NSView):
                   y + (row_h - pct_h) / 2, f_pct, _SEC)
 
         return y + row_h + 16   # 16 pts of bottom padding after the row
+
+    @objc.python_method
+    def _sparkline(
+        self,
+        buckets: list[float],
+        label: str,
+        x: float,
+        y: float,
+        w: float,
+    ) -> float:
+        """Draw a vertical-bar sparkline with a caption below; return new y.
+
+        Each bucket fills a thin vertical bar whose height scales with its
+        utilization (0.0-1.0). Empty buckets are skipped. Coordinates use the
+        view's flipped convention (origin top-left).
+        """
+        h = SPARK_H
+        _ns_color(*_TRACK).setFill()
+        _fill_rrect(x, y, w, h, 4)
+
+        if buckets:
+            n = len(buckets)
+            gap = 1.0
+            bar_w = max(1.0, (w - (n - 1) * gap) / n)
+            for i, val in enumerate(buckets):
+                if val <= 0:
+                    continue
+                bx = x + i * (bar_w + gap)
+                bh = max(1.0, h * min(float(val), 1.0))
+                # Flipped coords: bottom of bar = y + h, top = y + (h - bh)
+                _ns_color(*_BAR).setFill()
+                NSBezierPath.fillRect_(NSMakeRect(bx, y + (h - bh), bar_w, bh))
+
+        f = _sys_font(10)
+        _draw_str(label, x, y + h + 2, f, _DIM)
+        return y + SPARK_BLOCK_H
 
     @objc.python_method
     def _draw_separator(self, y: float) -> float:

--- a/config.json.example
+++ b/config.json.example
@@ -5,5 +5,7 @@
     "weekly_token_limit": 25000000,
     "refresh_seconds": 30,
     "osd_opacity": 0.75,
-    "osd_scale": 1.0
+    "osd_scale": 1.0,
+    "notifications_enabled": true,
+    "notify_thresholds": [0.75, 0.90]
 }

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,102 @@
+import json
+import os
+import tempfile
+import unittest
+
+from claude_usage.history import aggregate, append_sample, load_samples, prune
+
+
+class TestAggregate(unittest.TestCase):
+    def test_empty_points_returns_zeros(self):
+        self.assertEqual(aggregate([], "session", now=100, window_seconds=60, n_buckets=6), [0.0] * 6)
+
+    def test_invalid_params_return_empty(self):
+        self.assertEqual(aggregate([{"ts": 1, "session": 0.5}], "session", 100, 0, 6), [])
+        self.assertEqual(aggregate([{"ts": 1, "session": 0.5}], "session", 100, 60, 0), [])
+
+    def test_buckets_use_max_within_slice(self):
+        # window 60s, 6 buckets of 10s, now=100 → buckets cover [40,50),[50,60),...,[90,100]
+        points = [
+            {"ts": 45, "session": 0.30},
+            {"ts": 48, "session": 0.50},  # max in bucket 0
+            {"ts": 95, "session": 0.80},  # bucket 5
+        ]
+        result = aggregate(points, "session", now=100, window_seconds=60, n_buckets=6)
+        self.assertEqual(result[0], 0.50)
+        self.assertEqual(result[5], 0.80)
+        self.assertEqual(result[1], 0.0)
+
+    def test_points_outside_window_ignored(self):
+        points = [
+            {"ts": 10, "session": 0.99},  # before window
+            {"ts": 200, "session": 0.99},  # after now
+            {"ts": 50, "session": 0.40},
+        ]
+        result = aggregate(points, "session", now=100, window_seconds=60, n_buckets=6)
+        self.assertEqual(max(result), 0.40)
+
+    def test_picks_correct_key(self):
+        points = [{"ts": 50, "session": 0.10, "weekly": 0.90}]
+        s = aggregate(points, "session", now=100, window_seconds=60, n_buckets=6)
+        w = aggregate(points, "weekly", now=100, window_seconds=60, n_buckets=6)
+        self.assertEqual(max(s), 0.10)
+        self.assertEqual(max(w), 0.90)
+
+    def test_now_boundary_value_lands_in_last_bucket(self):
+        points = [{"ts": 100, "session": 0.7}]
+        result = aggregate(points, "session", now=100, window_seconds=60, n_buckets=6)
+        self.assertEqual(result[-1], 0.7)
+
+
+class TestPersistence(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
+        self.tmp.close()
+        self.path = self.tmp.name
+        os.unlink(self.path)  # let append_sample create it
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.unlink(self.path)
+
+    def test_append_and_load_roundtrip(self):
+        append_sample(self.path, ts=100.0, session_util=0.5, weekly_util=0.1)
+        append_sample(self.path, ts=200.0, session_util=0.6, weekly_util=0.2)
+        samples = load_samples(self.path)
+        self.assertEqual(len(samples), 2)
+        self.assertEqual(samples[0]["ts"], 100.0)
+        self.assertEqual(samples[1]["session"], 0.6)
+
+    def test_load_missing_file_returns_empty(self):
+        self.assertEqual(load_samples("/nonexistent/path.jsonl"), [])
+
+    def test_load_skips_corrupt_lines(self):
+        with open(self.path, "w") as f:
+            f.write('{"ts": 1, "session": 0.1, "weekly": 0.1}\n')
+            f.write("not valid json\n")
+            f.write('{"ts": 2, "session": 0.2, "weekly": 0.2}\n')
+        samples = load_samples(self.path)
+        self.assertEqual(len(samples), 2)
+
+    def test_load_filters_by_since_ts(self):
+        for i in range(5):
+            append_sample(self.path, ts=float(i * 100), session_util=0.1, weekly_util=0.1)
+        samples = load_samples(self.path, since_ts=250.0)
+        self.assertEqual(len(samples), 2)
+        self.assertEqual(samples[0]["ts"], 300.0)
+
+    def test_prune_drops_old_entries(self):
+        for i in range(5):
+            append_sample(self.path, ts=float(i * 100), session_util=0.1, weekly_util=0.1)
+        # cutoff = 400 - 250 = 150 → keep 200, 300, 400
+        kept = prune(self.path, keep_seconds=250.0, now=400.0)
+        self.assertEqual(kept, 3)
+        samples = load_samples(self.path)
+        self.assertEqual([s["ts"] for s in samples], [200.0, 300.0, 400.0])
+
+    def test_prune_missing_file_is_noop(self):
+        self.assertEqual(prune("/nonexistent/p.jsonl", keep_seconds=100, now=200), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,91 @@
+import unittest
+
+from claude_usage.collector import UsageStats
+from claude_usage.notifier import CrossingDetector, UsageNotifier
+
+
+class TestCrossingDetector(unittest.TestCase):
+    def test_first_call_never_fires(self):
+        d = CrossingDetector([0.75, 0.90])
+        self.assertEqual(d.check("session", 0.95), [])
+
+    def test_single_threshold_crossed(self):
+        d = CrossingDetector([0.75, 0.90])
+        d.check("session", 0.50)
+        self.assertEqual(d.check("session", 0.80), [0.75])
+
+    def test_multiple_thresholds_crossed_in_one_step(self):
+        d = CrossingDetector([0.75, 0.90])
+        d.check("session", 0.50)
+        self.assertEqual(d.check("session", 0.95), [0.75, 0.90])
+
+    def test_no_repeat_when_staying_above_threshold(self):
+        d = CrossingDetector([0.75, 0.90])
+        d.check("session", 0.50)
+        d.check("session", 0.80)
+        self.assertEqual(d.check("session", 0.85), [])
+
+    def test_reset_re_arms_threshold(self):
+        d = CrossingDetector([0.75])
+        d.check("session", 0.50)
+        d.check("session", 0.80)  # fires
+        d.check("session", 0.05)  # reset, no fire
+        self.assertEqual(d.check("session", 0.80), [0.75])
+
+    def test_scopes_are_independent(self):
+        d = CrossingDetector([0.75])
+        d.check("session", 0.50)
+        d.check("weekly", 0.50)
+        self.assertEqual(d.check("session", 0.80), [0.75])
+        self.assertEqual(d.check("weekly", 0.60), [])
+
+    def test_invalid_thresholds_are_dropped(self):
+        d = CrossingDetector([0.0, 0.5, 1.5, -0.1])
+        self.assertEqual(d.thresholds, [0.5])
+
+    def test_exact_threshold_value_counts_as_crossing(self):
+        d = CrossingDetector([0.75])
+        d.check("session", 0.50)
+        self.assertEqual(d.check("session", 0.75), [0.75])
+
+
+class TestUsageNotifier(unittest.TestCase):
+    def _notifier(self, **overrides):
+        cfg = {"notifications_enabled": True, "notify_thresholds": [0.75]}
+        cfg.update(overrides)
+        sent = []
+        n = UsageNotifier(cfg, sender=lambda title, body: sent.append((title, body)))
+        return n, sent
+
+    def test_fires_for_session_and_weekly(self):
+        n, sent = self._notifier(notify_thresholds=[0.75])
+        n.check_stats(UsageStats(session_utilization=0.50, weekly_utilization=0.50))
+        n.check_stats(UsageStats(session_utilization=0.80, weekly_utilization=0.80))
+        titles = [t for t, _ in sent]
+        self.assertEqual(len(titles), 2)
+        self.assertTrue(any("Session" in t for t in titles))
+        self.assertTrue(any("Weekly" in t for t in titles))
+
+    def test_disabled_sends_nothing(self):
+        n, sent = self._notifier(notifications_enabled=False)
+        n.check_stats(UsageStats(session_utilization=0.50))
+        n.check_stats(UsageStats(session_utilization=0.95))
+        self.assertEqual(sent, [])
+
+    def test_no_fire_on_first_observation(self):
+        n, sent = self._notifier()
+        n.check_stats(UsageStats(session_utilization=0.95, weekly_utilization=0.95))
+        self.assertEqual(sent, [])
+
+    def test_message_body_mentions_threshold(self):
+        n, sent = self._notifier(notify_thresholds=[0.75])
+        n.check_stats(UsageStats(session_utilization=0.50))
+        n.check_stats(UsageStats(session_utilization=0.80))
+        self.assertEqual(len(sent), 1)
+        title, body = sent[0]
+        self.assertIn("80%", title)
+        self.assertIn("75%", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two related additions on top of the existing widget:

- **Threshold notifications** — fires a desktop notification (libnotify on Linux, rumps on macOS) the first time session or weekly utilization crosses a configured threshold. Each scope is tracked independently, and crossings re-arm after a reset so a fresh approach to the limit will alert again. Defaults: `[0.75, 0.90]`, opt-out via `notifications_enabled: false` in `config.json`.
- **History sparklines** — each successful API sample is appended to `~/.claude/usage-history.jsonl`; the popup now renders a bucketed bar sparkline under each usage row (5h × 30 buckets for session, 7d × 28 buckets for weekly). Each bucket shows max utilization in its slice. Old samples are pruned at 8 days. Pure aggregation logic lives in `claude_usage/history.py` and is unit-tested without filesystem fixtures.

## Test plan

- [x] `python3 -m unittest discover tests` — 107/107 pass (24 new tests across `test_notifier.py` and `test_history.py`)
- [ ] Linux: launch the widget, confirm sparkline renders in the popup and a notification fires when crossing 75% / 90%
- [ ] macOS: same as above; popup window auto-resizes to fit the additional sparkline rows
- [ ] Set `"notifications_enabled": false` in `config.json` and confirm no notifications fire
- [ ] Wait one refresh cycle (30s default) and confirm a sample lands in `~/.claude/usage-history.jsonl`

## Notes

- The new `notifier.py` and `history.py` modules deliberately separate pure logic (`CrossingDetector`, `aggregate`) from I/O / platform calls so the interesting parts are testable.
- Sparkline drawing is duplicated across Cairo (Linux) and NSBezierPath (macOS) per the existing pattern in this repo — no shared abstraction.
- The rate-limit API call is unchanged (still a single 1-token Haiku request); history just persists the resulting utilization values for trend display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)