### PR TITLE
fix: specify utf-8 encoding while reading jsonl files

### DIFF
--- a/claude_usage/cache_analyzer.py
+++ b/claude_usage/cache_analyzer.py
@@ -115,7 +115,7 @@ def analyze_cache_opportunities(
 
         project = os.path.basename(os.path.dirname(jsonl_path))
         try:
-            f = open(jsonl_path)
+            f = open(jsonl_path, encoding="UTF-8")
         except OSError:
             continue
         with f:

--- a/claude_usage/collector.py
+++ b/claude_usage/collector.py
@@ -190,7 +190,7 @@ def _parse_tokens_file(
     those are the ones that carry the ``usage`` block with ``output_tokens``.
     """
     try:
-        f = open(path)
+        f = open(path, encoding="UTF-8")
     except OSError:
         return
 

--- a/claude_usage/ticker.py
+++ b/claude_usage/ticker.py
@@ -150,7 +150,7 @@ def scan_ticker_items(claude_dir: str, now: float | None = None) -> list[TickerI
 
     for path in _iter_recent_jsonl(projects_dir, cutoff_mtime):
         try:
-            f = open(path)
+            f = open(path, encoding="UTF-8")
         except OSError:
             continue
         with f:


### PR DESCRIPTION
Resolves `UnicodeDecodeError` occurring on Windows environments.

**Problem:** Python's `open()` function defaults to the system's local encoding (e.g., `cp1252` or `cp1254`) on Windows. This causes crashes when processing standard UTF-8 encoded `.jsonl` files.

**Solution:** Explicitly set `encoding='utf-8'` to ensure consistent behavior and cross-platform compatibility.
