### PR TITLE
Fix: add explicit UTF-8 encoding to all open() calls (fixes UnicodeDecodeError on Windows)

### DIFF
--- a/claude_usage/ai_report.py
+++ b/claude_usage/ai_report.py
@@ -55,7 +55,7 @@ def load_cached_report(claude_dir: str, now: float | None = None) -> WeeklyRepor
     if not os.path.isfile(path):
         return None
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8", errors="replace") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError):
         return None

--- a/claude_usage/collector.py
+++ b/claude_usage/collector.py
@@ -109,7 +109,7 @@ def parse_history(path: str) -> UsageStats:
     today_session_ids: set[str] = set()
     week_session_ids: set[str] = set()
 
-    with open(path) as f:
+    with open(path, encoding="utf-8", errors="replace") as f:
         for line in f:
             line = line.strip()
             if not line:
@@ -303,7 +303,7 @@ def _parse_conversation_tokens(
     breakdowns.
     """
     try:
-        f = open(path)
+        f = open(path, encoding="utf-8", errors="replace")
     except OSError:
         return
 
@@ -418,7 +418,7 @@ def _load_subscription_type(claude_dir: str) -> str:
     if not os.path.isfile(creds_path):
         return ""
     try:
-        with open(creds_path) as f:
+        with open(creds_path, encoding="utf-8", errors="replace") as f:
             creds = json.load(f)
         return str(creds.get("claudeAiOauth", {}).get("subscriptionType", ""))
     except (json.JSONDecodeError, OSError):
@@ -439,7 +439,7 @@ def _load_credentials(claude_dir: str) -> str | None:
     creds_path = os.path.join(claude_dir, ".credentials.json")
     if os.path.isfile(creds_path):
         try:
-            with open(creds_path) as f:
+            with open(creds_path, encoding="utf-8", errors="replace") as f:
                 creds = json.load(f)
             return creds["claudeAiOauth"]["accessToken"]
         except (json.JSONDecodeError, KeyError, OSError):

--- a/claude_usage/history.py
+++ b/claude_usage/history.py
@@ -18,7 +18,7 @@ def append_sample(path: str, ts: float, session_util: float, weekly_util: float)
         "weekly": float(weekly_util),
     })
     os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "a") as f:
+    with open(path, "a", encoding="utf-8") as f:
         f.write(line + "\n")
 
 
@@ -27,7 +27,7 @@ def load_samples(path: str, since_ts: float = 0.0) -> list[dict]:
     if not os.path.isfile(path):
         return []
     out = []
-    with open(path) as f:
+    with open(path, encoding="utf-8", errors="replace") as f:
         for line in f:
             line = line.strip()
             if not line:
@@ -51,7 +51,7 @@ def prune(path: str, keep_seconds: float, now: float) -> int:
     dirname = os.path.dirname(path) or "."
     fd, tmp_path = tempfile.mkstemp(dir=dirname, prefix=".history-", suffix=".tmp")
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             for entry in kept:
                 f.write(json.dumps(entry) + "\n")
         os.replace(tmp_path, path)


### PR DESCRIPTION
## Summary

On Windows with non-UTF-8 default code pages (e.g. Turkish cp1254, or any system where the ANSI code page is not UTF-8 compatible), the widget crashes with UnicodeDecodeError because several open() calls do not specify encoding="utf-8".

Python on Windows defaults to the system ANSI code page, which cannot decode UTF-8 characters present in Claude Code's JSONL files.

## Changes

Added encoding="utf-8" (and errors="replace" where reading) to all open() calls that were missing it:

- collector.py: parse_history, _parse_conversation_tokens, _load_subscription_type, _load_credentials
- history.py: append_sample, load_samples, prune
- ai_report.py: load_cached_report

Note: encoding="utf-8" is already the default on Linux/macOS, so this change has zero impact on those platforms -- it only fixes behavior on Windows.

## Reproduction

1. Use Windows with a non-UTF-8 system locale (Turkish, Japanese, etc.)
2. Have Claude Code sessions with non-ASCII characters in prompts/responses
3. Run claude-usage -- crashes with UnicodeDecodeError

## Tested on

- Windows 11 Pro (Turkish locale, cp1254)
- Python 3.12.3
- Widget version 0.6.7
