### PR TITLE
feat: add live Anthropic/Claude news ticker to OSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Gauge variants for every theme are available at `screenshots/osd-gauge-<theme>.p
 - **OSD overlay** -- transparent, frameless, always-on-top; left-click opens the details popup, right-click shows a context menu
 - **Live token stream** -- `● LIVE 5.3k tok/min` badge on the OSD while a Claude Code session is actively writing, derived from the conversation JSONLs
 - **Per-turn cost ticker** -- a scrolling strip at the bottom of the OSD shows the USD cost of each assistant turn as it lands (`$0.156 ← Bash · 116`), colour-coded by quartile within the visible window so the tape always stays visually varied. Toggle via right-click → "Show cost ticker" or set `"show_ticker": false` in `config.json`.
+- **Live news ticker** -- a second scrolling strip shows the latest Anthropic/Claude headlines sourced from Hacker News (top stories with 50+ upvotes). Fetched in the background, cached locally for 1 hour, and refreshed every 10 minutes. Click the strip to open the article in your browser. Toggle via right-click → "Show news ticker" or set `"show_news": false` in `config.json`.
 - **Subagent rozet** -- when you spawn parallel subagents via the Task tool, the `CLAUDE` title gets a `⚙ N` counter next to it showing how many are currently writing. Hidden when zero so single-session use isn't cluttered.
 - **Detail popup** -- usage bars, forecast, 5h/7d sparklines, 90-day heatmap, 52-week GitHub-style calendar, per-model cost breakdown, top projects, active sessions (resizable)
 - **Auto-refresh** -- every 30 seconds by default, fully configurable
@@ -170,6 +171,7 @@ python3 main.py
 - **Theme ▸** -- pick one of the 5 palettes; the choice persists to `~/.config/claude-usage/config.json` so a restart keeps it
 - **Minimize / Restore** -- collapse the OSD to a thin progress strip
 - **Show cost ticker** -- toggle the scrolling per-turn cost strip on the OSD
+- **Show news ticker** -- toggle the Anthropic/Claude news headline strip on the OSD
 - **Quit** -- exit the widget
 
 ## Configuration
@@ -204,6 +206,7 @@ cp config.json.example config.json
 | `claude_dir` | `~/.claude` | Path to the Claude Code data directory |
 | `theme` | `default` | Color theme for the OSD and popup. One of `default`, `catppuccin-mocha`, `dracula`, `nord`, `gruvbox-dark`, `terminal`, `dashboard`, `hud`, `receipt`, `strip`, `brutalist` |
 | `show_ticker` | `true` | Whether the scrolling per-turn cost ticker is painted at the bottom of the OSD. Toggle at runtime via right-click → "Show cost ticker". |
+| `show_news` | `true` | Whether the live Anthropic/Claude news headline strip is shown on the OSD. Toggle at runtime via right-click → "Show news ticker". |
 
 Keys omitted from `config.json` fall back to built-in defaults. `claude_dir` is not included in the example file because the default is correct for most setups.
 

--- a/claude_usage/collector.py
+++ b/claude_usage/collector.py
@@ -21,6 +21,7 @@ from claude_usage.live_stream import LiveActivity, detect_live_activity
 from claude_usage.subagents import count_active_subagents
 from claude_usage.ticker import TickerItem, scan_ticker_items
 from claude_usage.trends import daily_heatmap, hourly_histogram, monthly_summary
+from claude_usage.news_fetcher import NewsItem, get_news_items
 
 HISTORY_FILENAME = "usage-history.jsonl"
 HISTORY_KEEP_DAYS = 90  # keep 90 days for trend/anomaly analysis
@@ -86,6 +87,8 @@ class UsageStats:
     weekly_report_text: str = ""
     # Rolling per-turn cost feed for the OSD's scrolling ticker tape
     ticker_items: list[TickerItem] = field(default_factory=list)
+    # Recent Anthropic/Claude news from RSS, shown in the ticker tape
+    news_items: list[NewsItem] = field(default_factory=list)
     # Count of subagent JSONLs touched in the last minute — surfaced as the
     # "⚙ N" rozet next to the CLAUDE title when > 0.
     active_subagent_count: int = 0
@@ -774,6 +777,13 @@ def collect_all(config: dict[str, Any]) -> UsageStats:
         stats.active_subagent_count = count_active_subagents(claude_dir, now=now_ts)
     except OSError:
         stats.active_subagent_count = 0
+
+    # Recent Anthropic news — served from 1-hour local cache; network call
+    # is non-blocking because collect_all already runs in a daemon thread.
+    try:
+        stats.news_items = get_news_items()
+    except Exception:
+        stats.news_items = []
 
     # Claude-authored weekly report — we only *read* the on-disk cache here;
     # regeneration happens in a background thread from the widget so the

--- a/claude_usage/news_fetcher.py
+++ b/claude_usage/news_fetcher.py
@@ -1,0 +1,132 @@
+"""Fetches recent Anthropic/Claude news from RSS and caches locally.
+
+Network call happens at most once per hour. Falls back silently if offline.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.request
+import urllib.error
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+
+# Sources tried in order; first successful fetch wins.
+NEWS_RSS_SOURCES = [
+    "https://hnrss.org/newest?q=anthropic&points=50&count=10",  # at least 50 upvotes
+    "https://hnrss.org/newest?q=claude&points=50&count=10",     # fallback: claude keyword
+    "https://www.reddit.com/r/ClaudeAI.rss",                    # last resort
+]
+CACHE_TTL_SECONDS = 3600  # 1 hour
+MAX_NEWS_ITEMS = 8
+_CACHE_FILE = os.path.expanduser("~/.config/claude-usage/news-cache.json")
+
+
+@dataclass
+class NewsItem:
+    ts: float
+    title: str
+    url: str
+
+
+def _load_cache() -> tuple[float, list[NewsItem]] | None:
+    try:
+        with open(_CACHE_FILE, encoding="utf-8") as f:
+            data = json.load(f)
+        fetched_at = float(data["fetched_at"])
+        items = [NewsItem(ts=float(i["ts"]), title=i["title"], url=i["url"]) for i in data["items"]]
+        return fetched_at, items
+    except Exception:
+        return None
+
+
+def _save_cache(items: list[NewsItem]) -> None:
+    try:
+        os.makedirs(os.path.dirname(_CACHE_FILE), exist_ok=True)
+        with open(_CACHE_FILE, "w", encoding="utf-8") as f:
+            json.dump({
+                "fetched_at": time.time(),
+                "items": [{"ts": i.ts, "title": i.title, "url": i.url} for i in items],
+            }, f)
+    except Exception:
+        pass
+
+
+def _parse_entries(raw: bytes) -> list[NewsItem]:
+    from datetime import datetime, timezone
+    root = ET.fromstring(raw)
+    ns = {"atom": "http://www.w3.org/2005/Atom"}
+    items: list[NewsItem] = []
+    atom_entries = root.findall(".//atom:entry", ns)
+    entries = atom_entries if atom_entries else root.findall(".//item")
+    for entry in entries[:MAX_NEWS_ITEMS]:
+        title_el = entry.find("atom:title", ns)
+        if title_el is None:
+            title_el = entry.find("title")
+        title = (title_el.text or "").strip() if title_el is not None else ""
+        if not title:
+            continue
+
+        link_el = entry.find("atom:link", ns)
+        if link_el is not None:
+            item_url = link_el.get("href", "")
+        else:
+            link_el = entry.find("link")
+            item_url = (link_el.text or "").strip() if link_el is not None else ""
+
+        pub_el = (entry.find("atom:published", ns)
+                  or entry.find("atom:updated", ns)
+                  or entry.find("pubDate"))
+        ts = time.time()
+        if pub_el is not None and pub_el.text:
+            raw_date = pub_el.text.strip()
+            for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S%z",
+                        "%a, %d %b %Y %H:%M:%S %z", "%a, %d %b %Y %H:%M:%S GMT"):
+                try:
+                    dt = datetime.strptime(raw_date, fmt)
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                    ts = dt.timestamp()
+                    break
+                except ValueError:
+                    continue
+
+        items.append(NewsItem(ts=ts, title=title, url=item_url))
+    return items
+
+
+def _fetch_rss() -> list[NewsItem]:
+    for source_url in NEWS_RSS_SOURCES:
+        try:
+            req = urllib.request.Request(source_url, headers={"User-Agent": "claude-usage-widget/0.6"})
+            with urllib.request.urlopen(req, timeout=8) as resp:
+                raw = resp.read()
+            if raw:
+                return _parse_entries(raw)
+        except Exception:
+            continue
+    return []
+
+
+def get_news_items(force_refresh: bool = False) -> list[NewsItem]:
+    """Return cached news items, refreshing if the cache is stale."""
+    cached = _load_cache()
+    if cached and not force_refresh:
+        fetched_at, items = cached
+        if time.time() - fetched_at < CACHE_TTL_SECONDS:
+            return items
+
+    items = _fetch_rss()
+    if items:
+        _save_cache(items)
+        return items
+
+    # Network failed — return stale cache if available
+    if cached:
+        return cached[1]
+    return []
+
+
+__all__ = ["NewsItem", "get_news_items"]

--- a/claude_usage/overlay.py
+++ b/claude_usage/overlay.py
@@ -45,6 +45,8 @@ from claude_usage.ticker import TickerItem
 BASE_WIDTH = 260
 BASE_HEIGHT = 100
 TICKER_STRIP_HEIGHT = 22
+NEWS_STRIP_HEIGHT = 16  # second ticker row for latest headline
+NEWS_REFRESH_MS = 10 * 60 * 1000  # 10 minutes
 # Gauge view is slightly taller than bars because the rings + label + reset
 # stack vertically inside each column. No ticker in this view (it would
 # collide with the reset line under each ring).
@@ -178,10 +180,15 @@ class UsageOverlay(QWidget):
         # Ticker tape: newest-first. The paint loop walks them oldest→newest
         # so the newest item rides in from the right edge like a news ticker.
         self._ticker_items: list[TickerItem] = []
-        self._ticker_offset: float = 0.0  # pixels scrolled so far; grows each frame
+        self._news_items: list[NewsItem] = []
+        self._ticker_offset: float = 0.0
+        self._news_offset: float = 0.0   # separate scroll offset for news strip
+        self._latest_headline: str = ""  # single headline shown in news strip
+        self._latest_news_url: str = ""  # URL opened on click
         # User toggle — default on, overridable via config; runtime flip
         # lives in the right-click menu.
         self._ticker_enabled: bool = bool(cfg.get("show_ticker", True))
+        self._news_enabled: bool = bool(cfg.get("show_news", True))
         # "bars" (default) or "gauge" — the right-click menu toggles this and
         # persists to config.
         raw_mode = str(cfg.get("osd_view_mode", VIEW_MODE_BARS))
@@ -217,6 +224,12 @@ class UsageOverlay(QWidget):
         self._ticker_timer.setInterval(TICKER_FRAME_INTERVAL_MS)
         self._ticker_timer.timeout.connect(self._advance_ticker)
 
+        # News strip: refresh headline every 10 min, independent of stats refresh.
+        self._news_refresh_timer = QTimer(self)
+        self._news_refresh_timer.setInterval(NEWS_REFRESH_MS)
+        self._news_refresh_timer.timeout.connect(self._refresh_headline)
+        self._news_refresh_timer.start()
+
     # ------------------------------------------------------------------ API
 
     def update_stats(self, stats: UsageStats) -> None:
@@ -235,6 +248,11 @@ class UsageOverlay(QWidget):
             self._live_tpm = 0.0
         self._active_subagents = max(0, int(getattr(stats, "active_subagent_count", 0) or 0))
         self._ticker_items = list(getattr(stats, "ticker_items", []) or [])
+        new_news = list(getattr(stats, "news_items", []) or [])
+        if new_news:
+            self._news_items = new_news
+            self._latest_headline = new_news[0].title
+            self._latest_news_url = new_news[0].url
         # Animate whenever we have items and a view that actually draws the
         # ticker — default bars mode, or a skin that opts in via its
         # module-level WANTS_TICKER flag.
@@ -294,10 +312,31 @@ class UsageOverlay(QWidget):
         """Return True if the user has the cost-ticker strip enabled."""
         return self._ticker_enabled
 
+    def set_news_enabled(self, enabled: bool) -> None:
+        self._news_enabled = bool(enabled)
+        self.update()
+
+    def is_news_enabled(self) -> bool:
+        return self._news_enabled
+
     def _advance_ticker(self) -> None:
         """One frame of ticker scroll — called by the animation timer."""
         self._ticker_offset += TICKER_SCROLL_PX_PER_SEC * (TICKER_FRAME_INTERVAL_MS / 1000.0)
+        self._news_offset += TICKER_SCROLL_PX_PER_SEC * (TICKER_FRAME_INTERVAL_MS / 1000.0)
         self.update()
+
+    def _refresh_headline(self) -> None:
+        """Fetch latest news headline in a background thread."""
+        import threading
+        def _worker():
+            from claude_usage.news_fetcher import get_news_items
+            items = get_news_items(force_refresh=True)
+            if items:
+                self._news_items = items
+                self._latest_headline = items[0].title
+                self._latest_news_url = items[0].url
+                self._news_offset = 0.0
+        threading.Thread(target=_worker, daemon=True).start()
 
     def set_opacity(self, value: float) -> None:
         """Set background opacity (0.15 -- 1.0)."""
@@ -344,8 +383,6 @@ class UsageOverlay(QWidget):
 
         width = int(BASE_WIDTH * self._scale)
         if self._view_mode == VIEW_MODE_GAUGE:
-            # Gauge mode has no ticker — the reset line under each ring
-            # already occupies that footer real estate.
             base = GAUGE_HEIGHT
         else:
             # Receipt skin always reserves the footer strip for its barcode,
@@ -395,8 +432,14 @@ class UsageOverlay(QWidget):
         if event.button() != Qt.LeftButton:
             return
         if self._press_pos is not None and not self._dragging:
-            # It was a click (no drag) — open detail popup.
-            self.clicked.emit()
+            # Check if click landed on the news strip (bottom NEWS_STRIP_HEIGHT px).
+            click_y = event.position().y()
+            h = self.height()
+            if click_y >= h - NEWS_STRIP_HEIGHT * self._scale and self._latest_news_url:
+                import webbrowser
+                webbrowser.open(self._latest_news_url)
+            else:
+                self.clicked.emit()
         self._press_pos = None
         self._press_win_pos = None
         self._dragging = False
@@ -447,7 +490,26 @@ class UsageOverlay(QWidget):
                 self._last_stats, ticker_offset=self._ticker_offset,
             )
             try:
-                self._skin.paint_osd(p, QRectF(0, 0, w, h), data, self._scale)
+                s = self._scale
+                skin_h = int(self._skin.METRICS["osd_height"] * s)
+                self._skin.paint_osd(p, QRectF(0, 0, w, skin_h), data, self._scale)
+                # Draw news inside the skin's frame: above the skin's own ticker.
+                if getattr(self._skin, "WANTS_TICKER", False):
+                    pad_x = 14 * s
+                    if "news_bottom_pad" in self._skin.METRICS:
+                        news_y = skin_h - self._skin.METRICS["news_bottom_pad"] * s
+                    else:
+                        ticker_h = self._skin.METRICS.get("ticker_h", NEWS_STRIP_HEIGHT) * s
+                        news_y = skin_h - ticker_h - NEWS_STRIP_HEIGHT * s + 3 * s
+                    # Use same font as the skin's own ticker
+                    skin_fonts = getattr(self._skin, "FONTS", {})
+                    from claude_usage.skins._paint import mono_font as _skin_mono
+                    news_font = _skin_mono(
+                        9 * s,
+                        bold=True,
+                        family=skin_fonts.get("family_mono", "monospace"),
+                    )
+                    self._draw_news_strip(p, news_y, w, pad_x, s, font=news_font)
                 return
             except Exception:
                 # Swallow skin-paint errors and fall through to default paint
@@ -664,12 +726,13 @@ class UsageOverlay(QWidget):
         # thermal-chit design. The actual 1D barcode lives in the popup
         # footer (see widget.py), not here — it's a statement stamp, not
         # part of the at-a-glance overlay.
+        footer_y = y2 + 15 * s + bar_h + 6 * s
         if self._style.decoration == "receipt":
-            footer_y = y2 + 15 * s + bar_h + 6 * s
             self._paint_receipt_footer(p, pad_x, footer_y, w - 2 * pad_x, s)
         elif self._ticker_enabled:
-            ticker_y = y2 + 15 * s + bar_h + 6 * s
-            self._draw_ticker(p, ticker_y, w, pad_x, s)
+            self._draw_ticker(p, footer_y, w, pad_x, s)
+        # News strip: right after the ticker row
+        self._draw_news_strip(p, footer_y + 16 * s, w, pad_x, s)
 
     def _draw_ticker(
         self,
@@ -679,8 +742,10 @@ class UsageOverlay(QWidget):
         pad_x: float,
         s: float,
     ) -> None:
-        """Right-to-left scrolling tape of recent per-turn costs."""
-        if not self._ticker_items:
+        """Right-to-left scrolling tape of recent per-turn costs and news."""
+        has_costs = bool(self._ticker_items)
+        has_news = bool(self._news_items)
+        if not has_costs and not has_news:
             return
 
         # Tape geometry: clipped to the interior width so text doesn't spill
@@ -698,18 +763,12 @@ class UsageOverlay(QWidget):
         sep_gap = int(14 * s)
         baseline = y + tape_h - 3 * s
 
-        # Build display items oldest-first so the newest rides in from the
-        # right edge as offset grows. Duplicated list makes seamless looping
-        # cheap: as soon as the first copy fully scrolls off-screen, the
-        # second is already visible at its tail.
-        ordered = list(reversed(self._ticker_items))
-        strings = [self._format_ticker_item(it) for it in ordered]
+        # Cost items only — news is shown separately in the news strip below.
+        cost_ordered = list(reversed(self._ticker_items))
+        strings = [self._format_ticker_item(it) for it in cost_ordered]
         widths = [fm.horizontalAdvance(s_) + sep_gap for s_ in strings]
         strip_width = sum(widths) or 1
 
-        # x_start: the left edge of the first copy of the strip in absolute
-        # coordinates. Subtract the scrolling offset (modulo strip_width) so
-        # it drifts left indefinitely without integer overflow.
         x_start = tape_x + tape_w - (self._ticker_offset % strip_width)
         cost_colors = {
             "hot":    _hex_to_qcolor(self._theme["crit"]),
@@ -718,12 +777,10 @@ class UsageOverlay(QWidget):
             "dim":    _hex_to_qcolor(self._theme["text_dim"]),
         }
         thresholds = _ticker_quartile_thresholds(self._ticker_items)
-        # Enough copies to cover the viewport even when the strip is short —
-        # two copies only works when strip_width ≥ tape_w.
         copies = max(2, int(tape_w // strip_width) + 2)
         for repeat in range(copies):
             x = x_start + repeat * strip_width
-            for item, text, width in zip(ordered, strings, widths):
+            for item, text, width in zip(cost_ordered, strings, widths):
                 if x + width < tape_x:
                     x += width
                     continue
@@ -733,6 +790,49 @@ class UsageOverlay(QWidget):
                 p.drawText(QPointF(x, baseline), text)
                 x += width
 
+        p.restore()
+
+    def _draw_news_strip(
+        self,
+        p: QPainter,
+        y: float,
+        w: int,
+        pad_x: float,
+        s: float,
+        font: "QFont | None" = None,
+    ) -> None:
+        """Scrolling strip showing the latest news headline.
+
+        When news is disabled: text is shown statically from the left edge
+        (no scroll). When enabled: scrolls right-to-left as normal.
+        """
+        if not self._latest_headline:
+            return
+        tape_x = pad_x
+        tape_w = max(0.0, w - 2 * pad_x)
+        tape_h = 13 * s
+        p.save()
+        p.setClipRect(QRectF(tape_x, y - tape_h * 0.1, tape_w, tape_h * 1.2))
+        if font is None:
+            font = _mono_font(max(7, int(7.5 * s)))
+        p.setFont(font)
+        fm = p.fontMetrics()
+        baseline = y + tape_h - 3 * s
+        text = "📰 " + self._latest_headline + "    "
+        text_w = fm.horizontalAdvance(text) or 1
+        news_color = _hex_to_qcolor(self._theme.get("text_link", self._theme.get("warn", "#f59e0b")))
+        p.setPen(news_color)
+        if self._news_enabled:
+            x_start = tape_x + tape_w - (self._news_offset % text_w)
+            copies = max(2, int(tape_w // text_w) + 2)
+            for i in range(copies):
+                x = x_start + i * text_w
+                if x + text_w < tape_x or x > tape_x + tape_w:
+                    continue
+                p.drawText(QPointF(x, baseline), text)
+        else:
+            # Disabled: show static text from left edge (no scroll).
+            p.drawText(QPointF(tape_x, baseline), text)
         p.restore()
 
     @staticmethod

--- a/claude_usage/skins/brutalist.py
+++ b/claude_usage/skins/brutalist.py
@@ -51,7 +51,7 @@ THEME = {
 }
 
 METRICS = {
-    "osd_width": 360, "osd_height": 224, "osd_radius": 0, "osd_padding": 12,
+    "osd_width": 360, "osd_height": 200, "osd_radius": 0, "osd_padding": 12,
     "border_width": 2, "ticker_h": 22,
 }
 

--- a/claude_usage/skins/receipt.py
+++ b/claude_usage/skins/receipt.py
@@ -53,7 +53,8 @@ THEME = {
 }
 
 METRICS = {
-    "osd_width": 340, "osd_height": 234, "osd_radius": 2, "osd_padding": 16,
+    "osd_width": 340, "osd_height": 166, "osd_radius": 2, "osd_padding": 16,
+    "news_bottom_pad": 29,
     "popup_width": 540, "popup_padding": 26,
     "grain_step_px": 3, "ticker_h": 22,
 }
@@ -161,7 +162,7 @@ def paint_osd(p: QPainter, rect: QRectF, data, scale: float = 1.0) -> None:
         data.ticker_items, data.ticker_offset,
         ticker_colors, ticker_f, sep_gap_px=8 * s,
     )
-    yy = yy_base + fm_t.descent() + 6 * s
+    yy = yy_base + fm_t.descent() + 6 * s + 9 * s  # gap reserved for news strip
 
     # thank-you footer
     foot = "— THANK YOU —"

--- a/claude_usage/widget.py
+++ b/claude_usage/widget.py
@@ -1148,6 +1148,13 @@ class ClaudeUsageApp(QObject):
         self._act_ticker.setChecked(self.overlay.is_ticker_enabled())
         self._act_ticker.toggled.connect(self._on_toggle_ticker)
         m.addAction(self._act_ticker)
+
+        self._act_news = QAction("📰  Show news ticker", m)
+        self._act_news.setCheckable(True)
+        self._act_news.setChecked(self.overlay.is_news_enabled())
+        self._act_news.toggled.connect(self._on_toggle_news)
+        m.addAction(self._act_news)
+
         m.aboutToShow.connect(self._sync_menu_state)
 
         m.addSeparator()
@@ -1167,6 +1174,11 @@ class ClaudeUsageApp(QObject):
     def _on_toggle_ticker(self, checked: bool) -> None:
         self.overlay.set_ticker_enabled(checked)
         self.config["show_ticker"] = bool(checked)
+        self._persist_config()
+
+    def _on_toggle_news(self, checked: bool) -> None:
+        self.overlay.set_news_enabled(checked)
+        self.config["show_news"] = bool(checked)
         self._persist_config()
 
     def _on_pick_theme(self, name: str) -> None:
@@ -1366,6 +1378,7 @@ class ClaudeUsageApp(QObject):
 
         # Tick marks on radio-grouped items.
         self._act_ticker.setChecked(self.overlay.is_ticker_enabled())
+        self._act_news.setChecked(self.overlay.is_news_enabled())
         theme_act = self._theme_actions.get(current_theme)
         if theme_act is not None:
             theme_act.setChecked(True)


### PR DESCRIPTION
- New news_fetcher.py: fetches top HN stories about Anthropic/Claude (min 50 upvotes), caches locally for 1 hour, refreshes every 10 min
- News strip shown below cost ticker on all skins (WANTS_TICKER themes)
- Click the news strip to open the article in browser
- Right-click menu toggle "Show news ticker": scrolls when on, shows static text from left edge when off (mirrors cost ticker behavior)
- Toggle state persisted to config across restarts
- Skin-specific positioning fixes for brutalist and receipt themes
- README updated with feature docs