### PR TITLE
  feat: top-panel toggle + session-state persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Gauge variants for every theme are available at `screenshots/osd-gauge-<theme>.p
 - **Per-turn cost ticker** -- a scrolling strip at the bottom of the OSD shows the USD cost of each assistant turn as it lands (`$0.156 ← Bash · 116`), colour-coded by quartile within the visible window so the tape always stays visually varied. Toggle via right-click → "Show cost ticker" or set `"show_ticker": false` in `config.json`.
 - **Live news ticker (opt-in)** -- a second scrolling strip shows the latest Anthropic/Claude headlines sourced from Hacker News (top stories with 50+ upvotes). Fetched lazily, cached locally for 1 hour. Click the strip to open the article in your browser. **Off by default** because it makes outbound calls to a 3rd-party feed; enable via right-click → "Show news ticker" or set `"show_news": true` in `config.json`.
 - **Subagent rozet** -- when you spawn parallel subagents via the Task tool, the `CLAUDE` title gets a `⚙ N` counter next to it showing how many are currently writing. Hidden when zero so single-session use isn't cluttered.
+- **System-tray / menu-bar indicator** -- an optional tray entry shows `C: 42% | W: 71%` and a Show/Hide + Quit menu. Cross-platform: a live text label in the top bar on **Linux/GNOME** (AyatanaAppIndicator3), and a menu-bar icon on **macOS** / notification-area icon on **Windows** (Qt `QSystemTrayIcon`, no extra dependency). Auto-detected — if no tray backend is present the widget just runs without it.
 - **Detail popup** -- usage bars, forecast, 5h/7d sparklines, 90-day heatmap, 52-week GitHub-style calendar, per-model cost breakdown, top projects, active sessions (resizable)
 - **Auto-refresh** -- every 30 seconds by default, fully configurable
 - **Resizable** -- scroll wheel on the OSD (0.6x -- 2.0x); drag the popup window edges to widen it
@@ -267,11 +268,20 @@ The OSD renders a `● LIVE ~5.3k tok/min` badge when a Claude Code session is a
 
 ### Per-turn cost ticker
 
-A thin scrolling strip along the bottom of the OSD shows the USD cost of each assistant turn as it lands (`$0.156 ← Bash · 116`). The same JSONL scan that powers the live-tokens badge reads `usage.{input, output, cache_read, cache_creation}_tokens` from each unique message (dedup'd by Anthropic's `message.id`) and multiplies by the Anthropic-published rates in `pricing.py`. Multi-tool turns collapse to a compact `Read+2` label. Items are colour-coded by quartile rank within the current 40-item buffer (dim → blue → amber → red), so you always see four tiers regardless of whether you're on Haiku, Sonnet, or Opus — the tape stays meaningful when every turn happens to land in a narrow dollar band. Disable with the right-click menu or `show_ticker: false` in `config.json`.
+A thin scrolling strip along the bottom of the OSD shows the USD cost of each assistant turn as it lands (`$0.156 ← Bash · 116`). The same JSONL scan that powers the live-tokens badge reads `usage.{input, output, cache_read, cache_creation}_tokens` from each unique message (dedup'd by Anthropic's `message.id`) and multiplies by the Anthropic-published rates in `pricing.py` (kept current with the [official pricing page](https://claude.com/pricing) — Opus 4.8 / 4.7 / 4.6, Sonnet 4.6, Haiku 4.5; unknown models fall back to Sonnet rates with a one-time warning). Multi-tool turns collapse to a compact `Read+2` label. Items are colour-coded by quartile rank within the current 40-item buffer (dim → blue → amber → red), so you always see four tiers regardless of whether you're on Haiku, Sonnet, or Opus — the tape stays meaningful when every turn happens to land in a narrow dollar band. Disable with the right-click menu or `show_ticker: false` in `config.json`.
 
 ### Subagent rozet
 
 Right next to the `CLAUDE` title, a `⚙ N` badge shows how many Task-tool subagents are actively writing. Detection is a stat-only glob of `~/.claude/projects/<proj>/<uuid>/subagents/agent-*.jsonl` filtered to files whose mtime is within the last 60 s — no file contents opened, negligible cost on every refresh. The rozet is hidden when the count is zero so single-session users aren't nagged by a permanent `⚙ 0`.
+
+### System-tray / menu-bar indicator
+
+`tray_indicator.py` picks the best backend available for your platform, falling back gracefully:
+
+1. **Linux / GNOME / Ubuntu** — `AyatanaAppIndicator3` (via PyGObject) renders a live `C: 42% | W: 71%` text label right in the top bar. A GTK main loop runs in a daemon thread; label updates are marshalled to it through `GLib.idle_add`.
+2. **macOS / Windows / other Linux DEs** — Qt's built-in `QSystemTrayIcon` puts an icon in the menu bar (macOS) or notification area (Windows). macOS can't show a live text label beside a tray icon, so the stats appear in the dropdown menu and the hover tooltip instead. No extra dependency — Qt is already bundled with PySide6.
+
+Both backends expose the same menu — **Show/Hide widget** and **Quit claude-usage** (which fully shuts the widget down, not just the tray). If neither backend is available the widget runs normally without a tray. The OSD overlay always shows the live numbers regardless.
 
 ### Prompt-cache opportunities
 

--- a/README.md
+++ b/README.md
@@ -93,12 +93,13 @@ Gauge variants for every theme are available at `screenshots/osd-gauge-<theme>.p
 
 - **Single `pip install`** -- no `apt`/`brew`/system libraries required, Qt is bundled
 - **Real API data** -- rate-limit utilisation read straight from `anthropic-ratelimit-unified-*` response headers
-- **OSD overlay** -- transparent, frameless, always-on-top; left-click opens the details popup, right-click shows a context menu
+- **OSD overlay** -- transparent, frameless, always-on-top; left-click toggles the top panel indicator (when available), right-click shows a context menu
 - **Live token stream** -- `● LIVE 5.3k tok/min` badge on the OSD while a Claude Code session is actively writing, derived from the conversation JSONLs
 - **Per-turn cost ticker** -- a scrolling strip at the bottom of the OSD shows the USD cost of each assistant turn as it lands (`$0.156 ← Bash · 116`), colour-coded by quartile within the visible window so the tape always stays visually varied. Toggle via right-click → "Show cost ticker" or set `"show_ticker": false` in `config.json`.
 - **Live news ticker (opt-in)** -- a second scrolling strip shows the latest Anthropic/Claude headlines sourced from Hacker News (top stories with 50+ upvotes). Fetched lazily, cached locally for 1 hour. Click the strip to open the article in your browser. **Off by default** because it makes outbound calls to a 3rd-party feed; enable via right-click → "Show news ticker" or set `"show_news": true` in `config.json`.
 - **Subagent rozet** -- when you spawn parallel subagents via the Task tool, the `CLAUDE` title gets a `⚙ N` counter next to it showing how many are currently writing. Hidden when zero so single-session use isn't cluttered.
 - **System-tray / menu-bar indicator** -- an optional tray entry shows `C: 42% | W: 71%` and a Show/Hide + Quit menu. Cross-platform: a live text label in the top bar on **Linux/GNOME** (AyatanaAppIndicator3), and a menu-bar icon on **macOS** / notification-area icon on **Windows** (Qt `QSystemTrayIcon`, no extra dependency). Auto-detected — if no tray backend is present the widget just runs without it.
+- **Top panel toggle** -- show or hide the system-tray/menu-bar indicator from two places: **left-click** on the OSD widget directly toggles the panel on/off (single tap = open, second tap = close); or use the **⬛ Show top panel** checkable item in the right-click context menu. State persists to `config.json` (`show_panel`).
 - **Detail popup** -- usage bars, forecast, 5h/7d sparklines, 90-day heatmap, 52-week GitHub-style calendar, per-model cost breakdown, top projects, active sessions (resizable)
 - **Auto-refresh** -- every 30 seconds by default, fully configurable
 - **Resizable** -- scroll wheel on the OSD (0.6x -- 2.0x); drag the popup window edges to widen it
@@ -110,7 +111,7 @@ Gauge variants for every theme are available at `screenshots/osd-gauge-<theme>.p
 - **AI-generated weekly report** -- Claude Haiku writes a 3-4 sentence summary of your past week of usage (cached 1h; never leaks prompt text)
 - **Anomaly detection** -- flags days whose utilisation exceeds the 7/90-day baseline
 - **Cost optimisation tips** -- suggests cache-hit-rate improvements and model-mix changes
-- **Themes** -- default, catppuccin-mocha, dracula, nord, gruvbox-dark
+- **Themes** -- default, catppuccin-mocha, dracula, nord, gruvbox-dark, terminal, dashboard, hud, receipt, strip, brutalist
 - **Threshold notifications** -- native desktop notifications on crossing 75% / 90%
 - **Webhooks** -- optional POST to Slack / Discord / custom URLs on threshold, daily, or anomaly events
 - **Localhost JSON API** -- optional `http://127.0.0.1:8765/usage` for tmux / polybar / waybar integrations (prompt previews redacted at the serialization boundary)
@@ -158,7 +159,7 @@ python3 main.py
 
 | Action              | Effect |
 |---------------------|--------|
-| **Left-click**      | Open the details popup |
+| **Left-click**      | Toggle the top-panel indicator (open if closed, close if open). Falls back to opening the details popup when no tray backend is available. |
 | **Left-click drag** | Move the OSD |
 | **Right-click**     | Open context menu (Details, Refresh, Opacity, Minimize, Quit) |
 | **Scroll up / down**| Resize (0.6x -- 2.0x) |
@@ -170,10 +171,11 @@ python3 main.py
 - **OSD Opacity** -- 100% / 75% / 50% / 25%
 - **OSD View ▸** -- switch between **Bars** (default — progress bars + cost ticker) and **Gauge** (two circular rings); auto-persisted
 - **OSD Position ▸** -- snap the overlay to **Top Left / Top Right / Bottom Left / Bottom Right**, or drag it anywhere for a remembered **Custom** position; auto-persisted
-- **Theme ▸** -- pick one of the 5 palettes; the choice persists to `~/.config/claude-usage/config.json` so a restart keeps it
+- **Theme ▸** -- pick one of the 11 palettes; the choice persists to `~/.config/claude-usage/config.json` so a restart keeps it
 - **Minimize / Restore** -- collapse the OSD to a thin progress strip
 - **Show cost ticker** -- toggle the scrolling per-turn cost strip on the OSD
 - **Show news ticker** -- toggle the Anthropic/Claude news headline strip on the OSD
+- **Show top panel** -- toggle the system-tray / menu-bar indicator on or off; disabled when no tray backend is available
 - **Quit** -- exit the widget
 
 ## Configuration
@@ -209,8 +211,12 @@ cp config.json.example config.json
 | `theme` | `default` | Color theme for the OSD and popup. One of `default`, `catppuccin-mocha`, `dracula`, `nord`, `gruvbox-dark`, `terminal`, `dashboard`, `hud`, `receipt`, `strip`, `brutalist` |
 | `show_ticker` | `true` | Whether the scrolling per-turn cost ticker is painted at the bottom of the OSD. Toggle at runtime via right-click → "Show cost ticker". |
 | `show_news` | `false` | Whether the live Anthropic/Claude news headline strip is shown on the OSD. Off by default because it makes outbound calls to a 3rd-party feed. Toggle at runtime via right-click → "Show news ticker". |
+| `show_panel` | `true` | Whether the system-tray / menu-bar indicator is shown. Toggle at runtime via left-click on the OSD or right-click → "Show top panel". |
 | `osd_position` | `top-right` | Where the OSD anchors: `top-left`, `top-right`, `bottom-left`, `bottom-right`, or `custom`. Set from right-click → "OSD Position", or automatically to `custom` when you drag the overlay. |
 | `osd_x` / `osd_y` | `null` | Exact screen coordinates used only when `osd_position` is `custom`. Written automatically on drag. |
+| `osd_scale` | `1.0` | OSD zoom level (0.6–2.0). Updated automatically when you scroll the mouse wheel over the OSD. |
+| `osd_minimized` | `false` | Whether the OSD is in its collapsed thin-strip form. Toggled via right-click → "Minimize / Restore". |
+| `osd_visible` | `true` | Whether the OSD overlay is shown. Written on quit so the widget reopens in the same visible/hidden state. |
 
 Keys omitted from `config.json` fall back to built-in defaults. `claude_dir` is not included in the example file because the default is correct for most setups.
 
@@ -282,6 +288,12 @@ Right next to the `CLAUDE` title, a `⚙ N` badge shows how many Task-tool subag
 2. **macOS / Windows / other Linux DEs** — Qt's built-in `QSystemTrayIcon` puts an icon in the menu bar (macOS) or notification area (Windows). macOS can't show a live text label beside a tray icon, so the stats appear in the dropdown menu and the hover tooltip instead. No extra dependency — Qt is already bundled with PySide6.
 
 Both backends expose the same menu — **Show/Hide widget** and **Quit claude-usage** (which fully shuts the widget down, not just the tray). If neither backend is available the widget runs normally without a tray. The OSD overlay always shows the live numbers regardless.
+
+**Toggling the panel** — the indicator can be shown or hidden at any time without restarting:
+- **Left-click the OSD** — one tap shows the panel, a second tap hides it.
+- **Right-click the OSD → Show top panel** — a checkable menu item that mirrors the current state and persists the choice to `config.json` (`show_panel`).
+- On **AppIndicator** the indicator is moved to `PASSIVE` status (invisible in the top bar) rather than destroyed, so it reappears instantly on the next toggle.
+- On **Qt tray** `show()` / `hide()` is called on the underlying `QSystemTrayIcon`.
 
 ### Prompt-cache opportunities
 

--- a/claude_usage/overlay.py
+++ b/claude_usage/overlay.py
@@ -165,6 +165,10 @@ class UsageOverlay(QWidget):
     # Emitted after a drag-to-move finishes, with the new top-left (x, y).
     # The controller persists these as the "custom" position in config.
     movedTo = Signal(int, int)
+    # Emitted when the scroll-wheel changes the scale factor.
+    scaledTo = Signal(float)
+    # Emitted when the minimized state is toggled.
+    minimizedChanged = Signal(bool)
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
         super().__init__()
@@ -383,6 +387,7 @@ class UsageOverlay(QWidget):
         elif self._ticker_items and self._view_mode == VIEW_MODE_BARS:
             self._ticker_timer.start()
         self.update()
+        self.minimizedChanged.emit(self._minimized)
 
     # ------------------------------------------------------------- internals
 
@@ -523,6 +528,7 @@ class UsageOverlay(QWidget):
             self._scale = new_scale
             self._apply_size()
             self.update()
+            self.scaledTo.emit(self._scale)
 
     # ----------------------------------------------------------- painting
 

--- a/claude_usage/pricing.py
+++ b/claude_usage/pricing.py
@@ -19,6 +19,14 @@ from typing import Dict, Mapping
 # Prices are USD per 1,000,000 tokens.
 # Source: https://www.anthropic.com/pricing (April 2026)
 MODEL_PRICING: Dict[str, Dict[str, float]] = {
+    # Opus 4.8: same pricing tier as 4.7/4.6 — $5 input, $25 output,
+    # $6.25 5-min cache write, $0.50 cache read (per claude.com/pricing).
+    "claude-opus-4-8": {
+        "input": 5.0,
+        "output": 25.0,
+        "cache_read": 0.50,
+        "cache_creation": 6.25,
+    },
     # Opus 4.7 (April 2026): $5 input, $25 output — consistent across
     # Anthropic API, Bedrock, Vertex AI, and Foundry.
     "claude-opus-4-7": {

--- a/claude_usage/tray_indicator.py
+++ b/claude_usage/tray_indicator.py
@@ -1,0 +1,219 @@
+"""Cross-platform system-tray / menu-bar indicator.
+
+Two backends, picked in order by :func:`try_create`:
+
+1. **AyatanaAppIndicator3** (Linux / GNOME / Ubuntu) — shows a live text
+   label ("C: 42% | W: 71%") right in the top bar. Runs a GTK main loop in
+   a background daemon thread; all GTK calls are marshalled through
+   ``GLib.idle_add`` so they execute on the GTK thread.
+2. **QSystemTrayIcon** (macOS menu bar, Windows notification area, and any
+   Linux DE with a tray) — pure Qt, no extra dependency. macOS can't show a
+   live text label next to a tray icon, so the stats live in the dropdown
+   menu and the hover tooltip instead.
+
+If neither backend is available the widget runs fine without a tray.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from claude_usage.collector import UsageStats
+
+_ICON_DIR = os.path.join(os.path.dirname(__file__), "icons")
+_ICON_SVG = os.path.join(_ICON_DIR, "claude-tray.svg")
+# AppIndicator resolves names against the active icon theme; to use our own
+# SVG we must register its directory as an icon-theme path first.
+_ICON_THEME_NAME = "claude-tray" if os.path.exists(_ICON_SVG) else None
+
+
+def _try_import_gtk():
+    """Return (AyatanaAppIndicator3, GLib, Gtk) or raise ImportError."""
+    import gi
+    gi.require_version("AyatanaAppIndicator3", "0.1")
+    gi.require_version("Gtk", "3.0")
+    from gi.repository import AyatanaAppIndicator3, GLib, Gtk
+    return AyatanaAppIndicator3, GLib, Gtk
+
+
+def _format_label(stats: UsageStats) -> str:
+    """Shared "C: 42% | W: 71%" label used by both backends."""
+    s_pct = int(stats.session_utilization * 100)
+    w_pct = int(stats.weekly_utilization * 100)
+    return f"C: {s_pct}% | W: {w_pct}%"
+
+
+class AppIndicatorTray:
+    """Linux/GNOME top-bar indicator showing session + weekly utilisation."""
+
+    def __init__(self, on_toggle_widget=None, on_quit=None) -> None:
+        AyatanaAppIndicator3, GLib, Gtk = _try_import_gtk()
+        self._GLib = GLib
+        self._Gtk = Gtk
+        self._on_quit = on_quit
+
+        icon_name = _ICON_THEME_NAME or "dialog-information"
+        self._indicator = AyatanaAppIndicator3.Indicator.new(
+            "claude-usage",
+            icon_name,
+            AyatanaAppIndicator3.IndicatorCategory.APPLICATION_STATUS,
+        )
+        if _ICON_THEME_NAME:
+            self._indicator.set_icon_theme_path(_ICON_DIR)
+        self._indicator.set_status(AyatanaAppIndicator3.IndicatorStatus.ACTIVE)
+        self._indicator.set_label("C: …", "C: 100% | W: 100%")
+
+        # GTK needs a non-empty menu to show the indicator on some DE versions.
+        menu = Gtk.Menu()
+
+        if on_toggle_widget is not None:
+            item_toggle = Gtk.MenuItem(label="Show/Hide widget")
+            item_toggle.connect("activate", lambda _: on_toggle_widget())
+            menu.append(item_toggle)
+            menu.append(Gtk.SeparatorMenuItem())
+
+        item_quit = Gtk.MenuItem(label="Quit claude-usage")
+        item_quit.connect("activate", self._on_quit_clicked)
+        menu.append(item_quit)
+        menu.show_all()
+        self._indicator.set_menu(menu)
+
+        # Start GTK main loop in a daemon thread.
+        self._loop = GLib.MainLoop()
+        t = threading.Thread(target=self._loop.run, daemon=True)
+        t.start()
+
+    def update(self, stats: UsageStats) -> None:
+        """Update the label from any thread (marshalled to GTK thread)."""
+        label = _format_label(stats)
+        # guide string sets the column-width so the panel doesn't jitter
+        guide = "C: 100% | W: 100%"
+        indicator = self._indicator
+        self._GLib.idle_add(indicator.set_label, label, guide)
+
+    def _on_quit_clicked(self, _item) -> None:
+        # Stop the GTK loop, then hand off to the app's quit callback (which
+        # tears down the Qt side). Without on_quit we only stop GTK and the
+        # widget keeps running — historical behaviour, preserved as fallback.
+        self._loop.quit()
+        if self._on_quit is not None:
+            self._on_quit()
+
+    def destroy(self) -> None:
+        self._GLib.idle_add(self._loop.quit)
+
+
+class QtSystemTray:
+    """Cross-platform tray via :class:`QSystemTrayIcon`.
+
+    Works on macOS (menu bar), Windows (notification area), and Linux DEs
+    with a system tray. Must be constructed on the GUI thread with a live
+    ``QApplication``. macOS shows only the icon in the menu bar — the live
+    stats surface in the dropdown menu and the tooltip.
+    """
+
+    def __init__(self, on_toggle_widget=None, on_quit=None) -> None:
+        from PySide6.QtWidgets import (
+            QApplication,
+            QMenu,
+            QStyle,
+            QSystemTrayIcon,
+        )
+        from PySide6.QtGui import QAction, QIcon
+
+        if QApplication.instance() is None:
+            raise RuntimeError("QtSystemTray needs a running QApplication")
+        if not QSystemTrayIcon.isSystemTrayAvailable():
+            raise RuntimeError("No system tray available on this platform")
+
+        icon = QIcon(_ICON_SVG) if os.path.exists(_ICON_SVG) else QIcon()
+        if icon.isNull():
+            # Fall back to a stock icon so the menu bar still shows something.
+            icon = QApplication.instance().style().standardIcon(
+                QStyle.SP_ComputerIcon
+            )
+
+        self._tray = QSystemTrayIcon(icon)
+        self._tray.setToolTip("Claude Usage")
+
+        menu = QMenu()
+        # First row mirrors the AppIndicator label; disabled so it reads as a
+        # header rather than a clickable item.
+        self._status_action = QAction("C: … | W: …", menu)
+        self._status_action.setEnabled(False)
+        menu.addAction(self._status_action)
+        menu.addSeparator()
+
+        if on_toggle_widget is not None:
+            act_toggle = QAction("Show/Hide widget", menu)
+            act_toggle.triggered.connect(lambda: on_toggle_widget())
+            menu.addAction(act_toggle)
+
+        act_quit = QAction("Quit claude-usage", menu)
+        if on_quit is not None:
+            act_quit.triggered.connect(lambda: on_quit())
+        else:
+            act_quit.triggered.connect(
+                lambda: QApplication.instance().quit()
+            )
+        menu.addAction(act_quit)
+
+        # Keep a reference so the menu isn't garbage-collected.
+        self._menu = menu
+        self._tray.setContextMenu(menu)
+        # On macOS a left-click opens the same menu (no separate activate
+        # gesture), so wire activation to toggle the widget when present.
+        if on_toggle_widget is not None:
+            self._tray.activated.connect(
+                lambda reason: self._on_activated(reason, on_toggle_widget)
+            )
+        self._tray.show()
+
+    @staticmethod
+    def _on_activated(reason, on_toggle_widget) -> None:
+        from PySide6.QtWidgets import QSystemTrayIcon
+        # Trigger / DoubleClick = left-click on the icon. Right-click already
+        # raises the context menu, so don't double-fire on Context.
+        if reason in (
+            QSystemTrayIcon.Trigger,
+            QSystemTrayIcon.DoubleClick,
+        ):
+            on_toggle_widget()
+
+    def update(self, stats: UsageStats) -> None:
+        """Refresh the menu header + tooltip (already on the GUI thread)."""
+        label = _format_label(stats)
+        self._status_action.setText(label)
+        self._tray.setToolTip(f"Claude Usage — {label}")
+
+    def destroy(self) -> None:
+        self._tray.hide()
+
+
+def try_create(on_toggle_widget=None, on_quit=None):
+    """Return the best available tray backend, or ``None``.
+
+    Tries the GTK AppIndicator first (richest experience on GNOME/Ubuntu —
+    it shows a live text label), then falls back to the Qt system tray
+    (macOS / Windows / other Linux DEs). Returns ``None`` only when neither
+    is available, in which case the widget runs without a tray.
+    """
+    # GTK AppIndicator — Linux/GNOME only; raises on macOS/Windows where
+    # PyGObject or the indicator library isn't present.
+    try:
+        return AppIndicatorTray(
+            on_toggle_widget=on_toggle_widget, on_quit=on_quit
+        )
+    except (ImportError, ValueError):
+        pass
+
+    # Qt system tray — cross-platform fallback (this is the macOS path).
+    try:
+        return QtSystemTray(
+            on_toggle_widget=on_toggle_widget, on_quit=on_quit
+        )
+    except Exception:
+        return None

--- a/claude_usage/tray_indicator.py
+++ b/claude_usage/tray_indicator.py
@@ -65,6 +65,7 @@ class AppIndicatorTray:
             self._indicator.set_icon_theme_path(_ICON_DIR)
         self._indicator.set_status(AyatanaAppIndicator3.IndicatorStatus.ACTIVE)
         self._indicator.set_label("C: …", "C: 100% | W: 100%")
+        self._visible = True
 
         # GTK needs a non-empty menu to show the indicator on some DE versions.
         menu = Gtk.Menu()
@@ -93,6 +94,18 @@ class AppIndicatorTray:
         guide = "C: 100% | W: 100%"
         indicator = self._indicator
         self._GLib.idle_add(indicator.set_label, label, guide)
+
+    def set_visible(self, visible: bool) -> None:
+        """Show or hide the top-panel indicator (ACTIVE ↔ PASSIVE)."""
+        from gi.repository import AyatanaAppIndicator3
+        self._visible = visible
+        status = (AyatanaAppIndicator3.IndicatorStatus.ACTIVE
+                  if visible
+                  else AyatanaAppIndicator3.IndicatorStatus.PASSIVE)
+        self._GLib.idle_add(self._indicator.set_status, status)
+
+    def is_visible(self) -> bool:
+        return self._visible
 
     def _on_quit_clicked(self, _item) -> None:
         # Stop the GTK loop, then hand off to the app's quit callback (which
@@ -171,6 +184,7 @@ class QtSystemTray:
                 lambda reason: self._on_activated(reason, on_toggle_widget)
             )
         self._tray.show()
+        self._shown = True
 
     @staticmethod
     def _on_activated(reason, on_toggle_widget) -> None:
@@ -182,6 +196,17 @@ class QtSystemTray:
             QSystemTrayIcon.DoubleClick,
         ):
             on_toggle_widget()
+
+    def set_visible(self, visible: bool) -> None:
+        """Show or hide the system-tray icon."""
+        self._shown = visible
+        if visible:
+            self._tray.show()
+        else:
+            self._tray.hide()
+
+    def is_visible(self) -> bool:
+        return self._shown
 
     def update(self, stats: UsageStats) -> None:
         """Refresh the menu header + tooltip (already on the GUI thread)."""

--- a/claude_usage/widget.py
+++ b/claude_usage/widget.py
@@ -982,6 +982,8 @@ class ClaudeUsageApp(QObject):
 
     # Emitted on the GUI thread once background collection completes.
     stats_ready = Signal(object)
+    # Cross-thread bridge: GTK tray → Qt main thread toggle.
+    _tray_toggle = Signal()
 
     def __init__(self, config: dict[str, Any]) -> None:
         super().__init__()
@@ -1037,6 +1039,16 @@ class ClaudeUsageApp(QObject):
                     file=sys.stderr,
                 )
                 self._api_server = None
+
+        # Optional system-tray / menu-bar indicator. GTK AppIndicator on
+        # Linux/GNOME, QSystemTrayIcon on macOS/Windows — no-op if neither
+        # backend is available.
+        from claude_usage.tray_indicator import try_create as _tray_create
+        self._tray_toggle.connect(self._on_tray_toggle_widget)
+        self._tray = _tray_create(
+            on_toggle_widget=self._tray_toggle.emit,
+            on_quit=self._on_quit,
+        )
 
         # --- Wire signals ---
         self.overlay.clicked.connect(self._on_overlay_click)
@@ -1500,6 +1512,8 @@ class ClaudeUsageApp(QObject):
         self.popup.update_stats(stats)
         self.skin_popup.update_stats(stats)
         self.notifier.check_stats(stats)
+        if self._tray is not None:
+            self._tray.update(stats)
 
         # Webhook: anomaly
         if getattr(stats.anomaly, "is_anomaly", False):
@@ -1598,12 +1612,25 @@ class ClaudeUsageApp(QObject):
         except Exception:
             pass
 
+    @Slot()
+    def _on_tray_toggle_widget(self) -> None:
+        """Toggle the OSD overlay visibility; called via signal from the GTK tray."""
+        if self.overlay.isVisible():
+            self.overlay.hide()
+        else:
+            self.overlay.show()
+
     def _on_quit(self) -> None:
         self._alive = False
         self._timer.stop()
         if self._api_server is not None:
             try:
                 self._api_server.stop()
+            except Exception:
+                pass
+        if self._tray is not None:
+            try:
+                self._tray.destroy()
             except Exception:
                 pass
         QApplication.instance().quit()

--- a/claude_usage/widget.py
+++ b/claude_usage/widget.py
@@ -1049,15 +1049,23 @@ class ClaudeUsageApp(QObject):
             on_toggle_widget=self._tray_toggle.emit,
             on_quit=self._on_quit,
         )
+        if self._tray is not None and not bool(config.get("show_panel", True)):
+            self._tray.set_visible(False)
 
         # --- Wire signals ---
         self.overlay.clicked.connect(self._on_overlay_click)
         self.overlay.rightClicked.connect(self._on_overlay_right_click)
         self.overlay.movedTo.connect(self._on_overlay_moved)
+        self.overlay.scaledTo.connect(self._on_overlay_scaled)
+        self.overlay.minimizedChanged.connect(self._on_overlay_minimized_changed)
         self.stats_ready.connect(self._apply_stats)
 
-        # Show the overlay and kick off the first refresh.
+        # Show the overlay, then restore last-session state.
         self.overlay.show()
+        if config.get("osd_minimized", False):
+            self.overlay.toggle_minimized()
+        if not config.get("osd_visible", True):
+            self.overlay.hide()
         self._refresh_async()
 
         # Periodic refresh timer (runs on the GUI thread).
@@ -1194,6 +1202,12 @@ class ClaudeUsageApp(QObject):
         self._act_news.toggled.connect(self._on_toggle_news)
         m.addAction(self._act_news)
 
+        self._act_panel = QAction("⬛  Show top panel", m)
+        self._act_panel.setCheckable(True)
+        self._act_panel.setChecked(bool(self.config.get("show_panel", True)))
+        self._act_panel.toggled.connect(self._on_toggle_panel)
+        m.addAction(self._act_panel)
+
         m.aboutToShow.connect(self._sync_menu_state)
 
         m.addSeparator()
@@ -1218,6 +1232,12 @@ class ClaudeUsageApp(QObject):
     def _on_toggle_news(self, checked: bool) -> None:
         self.overlay.set_news_enabled(checked)
         self.config["show_news"] = bool(checked)
+        self._persist_config()
+
+    def _on_toggle_panel(self, checked: bool) -> None:
+        if self._tray is not None:
+            self._tray.set_visible(checked)
+        self.config["show_panel"] = bool(checked)
         self._persist_config()
 
     def _on_pick_theme(self, name: str) -> None:
@@ -1256,6 +1276,14 @@ class ClaudeUsageApp(QObject):
         self.config["osd_position"] = "custom"
         self.config["osd_x"] = int(x)
         self.config["osd_y"] = int(y)
+        self._persist_config()
+
+    def _on_overlay_scaled(self, scale: float) -> None:
+        self.config["osd_scale"] = round(float(scale), 3)
+        self._persist_config()
+
+    def _on_overlay_minimized_changed(self, minimized: bool) -> None:
+        self.config["osd_minimized"] = bool(minimized)
         self._persist_config()
 
     def _on_pick_opacity(self, value: float, pct: int) -> None:
@@ -1435,6 +1463,10 @@ class ClaudeUsageApp(QObject):
         # Tick marks on radio-grouped items.
         self._act_ticker.setChecked(self.overlay.is_ticker_enabled())
         self._act_news.setChecked(self.overlay.is_news_enabled())
+        panel_visible = (self._tray.is_visible() if self._tray is not None
+                         else False)
+        self._act_panel.setChecked(panel_visible)
+        self._act_panel.setEnabled(self._tray is not None)
         theme_act = self._theme_actions.get(current_theme)
         if theme_act is not None:
             theme_act.setChecked(True)
@@ -1550,7 +1582,14 @@ class ClaudeUsageApp(QObject):
     # -------------------------------------------------------------- slots
 
     def _on_overlay_click(self) -> None:
-        self._show_popup()
+        if self._tray is None:
+            self._show_popup()
+            return
+        # Sol tık: üst panel göstergesini aç/kapa (toggle)
+        new_visible = not self._tray.is_visible()
+        self._tray.set_visible(new_visible)
+        self.config["show_panel"] = new_visible
+        self._persist_config()
 
     def _on_overlay_right_click(self, global_pos: QPoint) -> None:
         self._context_menu.popup(global_pos)
@@ -1621,6 +1660,10 @@ class ClaudeUsageApp(QObject):
             self.overlay.show()
 
     def _on_quit(self) -> None:
+        # Persist final overlay state before teardown.
+        self.config["osd_visible"] = bool(self.overlay.isVisible())
+        self._persist_config()
+
         self._alive = False
         self._timer.stop()
         if self._api_server is not None:


### PR DESCRIPTION
Description:
  - Left-click OSD toggles the system-tray indicator on/off
  - Added 'Show top panel' checkbox to right-click context menu
  - Widget now restores scale, minimize, and visibility state on restart
