### PR TITLE
Fix: bill unknown models at their family's rate instead of Sonnet

### DIFF
--- a/claude_usage/pricing.py
+++ b/claude_usage/pricing.py
@@ -66,8 +66,21 @@ MODEL_PRICING: Dict[str, Dict[str, float]] = {
     },
 }
 
-# Fallback model used whenever a caller passes an unknown model identifier.
+# Fallback model used whenever a caller passes an unknown model identifier
+# that we can't even resolve to a family (see _family_fallback_model).
 _FALLBACK_MODEL = "claude-sonnet-4-6"
+
+# Per-family fallback used when an exact model id is unknown but its family
+# name is recognisable from the id (e.g. a freshly released "claude-opus-4-8"
+# before the table above is updated). Anthropic embeds the family in every
+# model id, so matching on it keeps a new point release billed at its real
+# tier instead of being silently under-reported at Sonnet rates. Each value
+# points at the most recent known member of that family.
+_FAMILY_FALLBACK: Dict[str, str] = {
+    "opus": "claude-opus-4-7",
+    "sonnet": "claude-sonnet-4-6",
+    "haiku": "claude-haiku-4-5-20251001",
+}
 
 # Conversion factor: prices are per one million tokens.
 _PER_MILLION = 1_000_000.0
@@ -76,18 +89,39 @@ _PER_MILLION = 1_000_000.0
 _WARNED_MODELS: set[str] = set()
 
 
+def _family_fallback_model(model: str) -> str | None:
+    """Best-effort map an unknown model id to a known same-family model.
+
+    Anthropic model ids embed the family name (``claude-opus-4-8``,
+    ``claude-sonnet-4-6``), so a substring match lets a newly released point
+    version inherit the correct pricing tier until ``MODEL_PRICING`` is
+    updated. Returns ``None`` when no family token is recognised.
+    """
+    lowered = model.lower()
+    for family, representative in _FAMILY_FALLBACK.items():
+        if family in lowered:
+            return representative
+    return None
+
+
 def _resolve_pricing(model: str) -> Dict[str, float]:
-    """Return the pricing table for ``model``, warning once per unknown model."""
+    """Return the pricing table for ``model``, warning once per unknown model.
+
+    Unknown exact ids are first resolved by *family* (so a new Opus release is
+    billed at the Opus tier, not Sonnet's), and only fall back to the generic
+    :data:`_FALLBACK_MODEL` when even the family is unrecognisable.
+    """
     pricing = MODEL_PRICING.get(model)
     if pricing is not None:
         return pricing
+    fallback = _family_fallback_model(model) or _FALLBACK_MODEL
     if model not in _WARNED_MODELS:
         _WARNED_MODELS.add(model)
         warnings.warn(
-            f"Unknown model {model!r}; falling back to {_FALLBACK_MODEL} pricing.",
+            f"Unknown model {model!r}; falling back to {fallback} pricing.",
             stacklevel=3,
         )
-    return MODEL_PRICING[_FALLBACK_MODEL]
+    return MODEL_PRICING[fallback]
 
 
 def calculate_cost(

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -105,6 +105,28 @@ class TestCalculateCostUnknownModel:
         calculate_cost("", 0, 0)
         calculate_cost("totally-made-up", 1, 2, 3, 4)
 
+    def test_unknown_opus_falls_back_to_opus_pricing(self):
+        """A not-yet-tabled Opus release (e.g. claude-opus-4-8) must be billed
+        at the Opus tier ($5/M input, $25/M output), NOT the generic Sonnet
+        fallback — otherwise Opus usage is silently under-reported by ~40%."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = calculate_cost("claude-opus-4-8", 1_000_000, 1_000_000)
+        assert _approx(result["input"], 5.0)
+        assert _approx(result["output"], 25.0)
+        # The warning should name the family fallback, not Sonnet.
+        assert any("claude-opus-4-7" in str(w.message) for w in caught)
+
+    def test_unknown_haiku_falls_back_to_haiku_pricing(self):
+        """An unknown Haiku id resolves to the Haiku tier ($1/M input)."""
+        result = calculate_cost("claude-haiku-9-9", 1_000_000, 0)
+        assert _approx(result["input"], 1.0)
+
+    def test_unrecognisable_family_still_falls_back_to_sonnet(self):
+        """No family token in the id → the generic Sonnet fallback ($3/M)."""
+        result = calculate_cost("claude-imaginary-9", 1_000_000, 0)
+        assert _approx(result["input"], 3.0)
+
     def test_synthetic_model_is_zero_cost_and_silent(self):
         """<synthetic> is Claude Code's placeholder for internal bookkeeping
         (compact summaries, sidechain context, etc.). It should NOT trigger


### PR DESCRIPTION
## Problem
`_resolve_pricing` falls back to Sonnet pricing for any model id not in
`MODEL_PRICING`. As soon as a new model ships (e.g. `claude-opus-4-8`), its
usage is silently billed at Sonnet's $3/$15 instead of Opus's $5/$25 —
under-reporting cost by ~40% until the table is updated. Running the widget
on Opus 4.8 hits it immediately:

    UserWarning: Unknown model 'claude-opus-4-8'; falling back to claude-sonnet-4-6 pricing.

## Fix
Resolve unknown ids by *family* first. Anthropic embeds the family name in
every id, so an unknown `claude-opus-*` now inherits the latest known Opus
tier, `claude-haiku-*` the Haiku tier, etc. Only when no family token is
recognised do we keep the existing generic Sonnet fallback. No invented
prices — a new point release simply tracks its family until the table is
updated.

## Tests
Added 3 cases to `TestCalculateCostUnknownModel`:
- unknown Opus → Opus tier ($5/$25)
- unknown Haiku → Haiku tier ($1)
- unrecognisable family → Sonnet fallback (existing behaviour preserved)

All pass: `pytest tests/test_pricing.py`.