### PR TITLE
fix: keep OSD and popups visible on macOS when app loses focus

### DIFF
--- a/claude_usage/overlay.py
+++ b/claude_usage/overlay.py
@@ -250,6 +250,11 @@ class UsageOverlay(QWidget):
         # NET_WM hint: tell the window manager this is a Notification, so dock
         # / taskbar / Alt-Tab overlays all skip it.
         self.setAttribute(Qt.WA_X11NetWmWindowTypeNotification, True)
+        # macOS hides Qt.Tool windows whenever the owning app is deactivated
+        # (i.e. you click another app), so the OSD would silently vanish on
+        # focus loss even though the process keeps running. This attribute
+        # opts out of that Cocoa behaviour; it's a no-op on other platforms.
+        self.setAttribute(Qt.WA_MacAlwaysShowToolWindow, True)
 
         # Initial size + position (top-right of primary screen).
         self._apply_size()

--- a/claude_usage/widget.py
+++ b/claude_usage/widget.py
@@ -342,6 +342,9 @@ class SkinPopupWidget(QWidget):
         self.setWindowTitle("Claude Usage")
         self.setWindowFlags(Qt.Tool | Qt.WindowStaysOnTopHint | Qt.WindowCloseButtonHint)
         self.setAttribute(Qt.WA_X11NetWmWindowTypeUtility, True)
+        # macOS auto-hides Qt.Tool windows when the app deactivates; keep this
+        # popup visible when the user clicks away (no-op off macOS).
+        self.setAttribute(Qt.WA_MacAlwaysShowToolWindow, True)
 
         # Inner content widget sized to measure_popup output; wrapped in
         # a scroll area so the window is resizable without losing content.
@@ -533,6 +536,9 @@ class UsagePopup(QWidget):
         # Reinforce "don't show me in the dock" via the NET_WM window-type
         # hint. Utility windows are excluded from KDE/GNOME taskbars by spec.
         self.setAttribute(Qt.WA_X11NetWmWindowTypeUtility, True)
+        # macOS auto-hides Qt.Tool windows when the app deactivates; keep this
+        # popup visible when the user clicks away (no-op off macOS).
+        self.setAttribute(Qt.WA_MacAlwaysShowToolWindow, True)
 
         # Style sheet — applied once per instance.
         self.setStyleSheet(self._build_qss())


### PR DESCRIPTION
On macOS, Qt automatically hides Qt.Tool windows whenever the owning application is deactivated (i.e. the user clicks another app). All three of the widget's windows use Qt.Tool, so the OSD overlay and detail popups silently vanished on focus loss even though the process kept running.

Set Qt.WA_MacAlwaysShowToolWindow on each window to opt out of this Cocoa behaviour. The attribute is macOS-specific and a no-op on Linux/Windows, so no platform gating is needed.