### PR TITLE
Add opt-in Codex provider: OpenAI Codex rate limits alongside Claude's

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ cp config.json.example config.json
 | `refresh_max_seconds` | `300` | Max poll interval when the API rate-limits/errors; the interval backs off exponentially toward this cap and snaps back to `refresh_seconds` on the next clean refresh |
 | `osd_opacity` | `0.75` | OSD background opacity (0.15--1.0) |
 | `osd_scale` | `1.0` | OSD scale factor (0.6--2.0) |
+| `providers` | `["claude"]` | Add `"codex"` to also poll the local OpenAI Codex CLI (`codex app-server`) and show its 5h/weekly usage beneath Claude's — an extra ring row in gauge view, two extra bars in bars view. POSIX-only. |
+| `codex_poll_seconds` | `300` | How often (seconds) to spawn the codex app-server RPC; an on-disk cache is served in between. |
 | `daily_message_limit` | `200` | Daily message limit for local tracking in the popup |
 | `weekly_message_limit` | `1000` | Weekly message limit for local tracking in the popup |
 | `daily_token_limit` | `5000000` | Daily token limit for local tracking |

--- a/claude_usage/codex.py
+++ b/claude_usage/codex.py
@@ -1,0 +1,220 @@
+"""OpenAI Codex rate-limit collector (opt-in second provider).
+
+Talks to the local ``codex`` CLI's ``app-server`` over stdio JSON-RPC:
+``initialize`` -> ``initialized`` -> ``account/rateLimits/read``. The
+response carries a ``rateLimits`` object with a ``primary`` (~5h) and
+``secondary`` (weekly) window, each with ``usedPercent`` and ``resetsAt``
+— the same shape as Claude's session/weekly pair, so the overlay can
+render them with the exact same ring/bar primitives.
+
+Spawning the app-server takes a couple of seconds, so results are cached
+on disk (`~/.cache/claude-usage/codex_limits.json`) and only refreshed
+every ``poll_seconds``. Between polls — and on RPC failure — the cache is
+served, with expired windows clamped back to zero exactly like the Claude
+sample-fallback path in ``collector.collect_all``.
+
+POSIX-only for now: the reader uses ``select`` on pipes, which does not
+work on Windows. On other platforms ``collect_codex`` reports
+unavailable and the UI simply never shows the Codex rows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import select
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+RPC_TIMEOUT_SECONDS = 12
+DEFAULT_POLL_SECONDS = 300
+CACHE_PATH = Path.home() / ".cache" / "claude-usage" / "codex_limits.json"
+_BIN_CANDIDATES = ("/opt/homebrew/bin/codex", "/usr/local/bin/codex")
+
+
+def find_codex_bin() -> str | None:
+    """Locate the ``codex`` CLI, preferring whatever is on PATH."""
+    which = shutil.which("codex")
+    if which:
+        return which
+    for candidate in _BIN_CANDIDATES:
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def _rate_limits_rpc(codex_bin: str, timeout: float = RPC_TIMEOUT_SECONDS) -> dict[str, Any] | None:
+    """Run one ``account/rateLimits/read`` round-trip against ``codex app-server``."""
+    proc = subprocess.Popen(
+        [codex_bin, "app-server"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+
+    def send(obj: dict[str, Any]) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(obj) + "\n")
+        proc.stdin.flush()
+
+    result: dict[str, Any] | None = None
+    try:
+        send({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"clientInfo": {
+                "name": "claude-usage-widget",
+                "title": "Claude Usage Widget",
+                "version": "0",
+            }},
+        })
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline and result is None:
+            assert proc.stdout is not None
+            ready, _, _ = select.select(
+                [proc.stdout], [], [], max(0.0, deadline - time.monotonic()))
+            if not ready:
+                break
+            line = proc.stdout.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line)
+            except ValueError:
+                continue
+            if msg.get("id") == 1:
+                send({"jsonrpc": "2.0", "method": "initialized"})
+                # The app-server needs a beat between the handshake and the
+                # first real request or it drops it on the floor.
+                time.sleep(0.6)
+                send({"jsonrpc": "2.0", "id": 2,
+                      "method": "account/rateLimits/read", "params": {}})
+            elif msg.get("id") == 2:
+                result = msg.get("result")
+    finally:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+    return result
+
+
+def parse_rate_limits(payload: Any) -> dict[str, Any] | None:
+    """Extract the two utilization windows from a rateLimits/read result.
+
+    Returns ``{"session_pct", "session_reset", "weekly_pct", "weekly_reset"}``
+    (pct 0..1, reset as unix seconds, 0 when absent), or None when the
+    payload has no usable window data.
+    """
+    if not isinstance(payload, dict):
+        return None
+    limits = payload.get("rateLimits")
+    if not isinstance(limits, dict):
+        return None
+
+    def window(block: Any) -> tuple[float, int] | None:
+        if not isinstance(block, dict) or block.get("usedPercent") is None:
+            return None
+        try:
+            pct = max(0.0, min(1.0, float(block["usedPercent"]) / 100.0))
+        except (TypeError, ValueError):
+            return None
+        reset = block.get("resetsAt")
+        try:
+            reset_ts = int(reset) if reset is not None else 0
+        except (TypeError, ValueError):
+            reset_ts = 0
+        if reset_ts > 10**12:  # milliseconds — normalise to seconds
+            reset_ts //= 1000
+        return pct, reset_ts
+
+    primary = window(limits.get("primary"))
+    secondary = window(limits.get("secondary"))
+    if primary is None and secondary is None:
+        return None
+    return {
+        "session_pct": primary[0] if primary else 0.0,
+        "session_reset": primary[1] if primary else 0,
+        "weekly_pct": secondary[0] if secondary else 0.0,
+        "weekly_reset": secondary[1] if secondary else 0,
+    }
+
+
+def _load_cache() -> dict[str, Any] | None:
+    try:
+        with open(CACHE_PATH, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def _save_cache(payload: dict[str, Any]) -> None:
+    try:
+        CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = CACHE_PATH.with_suffix(".tmp")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump({"fetched_at": time.time(), "payload": payload}, fh)
+        os.replace(tmp, CACHE_PATH)
+    except OSError:
+        pass
+
+
+def _clamp_expired(parsed: dict[str, Any], now_ts: float) -> dict[str, Any]:
+    """A window whose reset has passed has rolled over — show 0, not stale %."""
+    out = dict(parsed)
+    if out["session_reset"] and now_ts >= out["session_reset"]:
+        out["session_pct"], out["session_reset"] = 0.0, 0
+    if out["weekly_reset"] and now_ts >= out["weekly_reset"]:
+        out["weekly_pct"], out["weekly_reset"] = 0.0, 0
+    return out
+
+
+def collect_codex(poll_seconds: int = DEFAULT_POLL_SECONDS) -> dict[str, Any]:
+    """Return Codex utilization for the overlay; never raises.
+
+    ``{"available": bool, "session_pct", "session_reset", "weekly_pct",
+    "weekly_reset", "error": str}`` — available=False hides the Codex UI.
+    """
+    unavailable = {
+        "available": False, "error": "",
+        "session_pct": 0.0, "session_reset": 0,
+        "weekly_pct": 0.0, "weekly_reset": 0,
+    }
+    if os.name != "posix":
+        return {**unavailable, "error": "codex provider is POSIX-only for now"}
+    codex_bin = find_codex_bin()
+    if codex_bin is None:
+        return {**unavailable, "error": "codex binary not found"}
+
+    now_ts = time.time()
+    cache = _load_cache()
+    if cache is not None:
+        age = now_ts - float(cache.get("fetched_at", 0) or 0)
+        parsed = parse_rate_limits(cache.get("payload"))
+        if parsed is not None and 0 <= age < poll_seconds:
+            return {"available": True, "error": "", **_clamp_expired(parsed, now_ts)}
+
+    payload = None
+    try:
+        payload = _rate_limits_rpc(codex_bin)
+    except OSError:
+        payload = None
+    parsed = parse_rate_limits(payload)
+    if parsed is not None:
+        assert isinstance(payload, dict)
+        _save_cache(payload)
+        return {"available": True, "error": "", **_clamp_expired(parsed, now_ts)}
+
+    # RPC failed — fall back to any cache, however old, before giving up.
+    if cache is not None:
+        parsed = parse_rate_limits(cache.get("payload"))
+        if parsed is not None:
+            return {"available": True, "error": "rpc failed; serving cache",
+                    **_clamp_expired(parsed, now_ts)}
+    return {**unavailable, "error": "rateLimits/read returned no window data"}

--- a/claude_usage/collector.py
+++ b/claude_usage/collector.py
@@ -19,6 +19,7 @@ from urllib.request import Request, urlopen
 
 from claude_usage import forecast, pricing
 from claude_usage import budget as _budget
+from claude_usage import codex as _codex
 from claude_usage import peak as _peak
 from claude_usage.analytics import AnomalyReport, detect_anomaly, generate_tips
 from claude_usage.burn import (
@@ -78,6 +79,14 @@ class UsageStats:
     scoped_utilization: float = 0.0
     scoped_reset: int = 0
     scoped_label: str = ""
+    # Optional second provider: OpenAI Codex rate limits, populated only when
+    # "codex" is listed in the `providers` config key. codex_available=False
+    # means the overlay draws no Codex rows at all.
+    codex_available: bool = False
+    codex_session_utilization: float = 0.0
+    codex_session_reset: int = 0
+    codex_weekly_utilization: float = 0.0
+    codex_weekly_reset: int = 0
     overage_status: str = ""  # "rejected" or "allowed"
     fallback_status: str = ""  # "available" or ""
     rate_limit_error: str = ""  # error message if API call fails
@@ -1199,5 +1208,20 @@ def collect_all(config: dict[str, Any]) -> UsageStats:
         stats.peak_hint = ps.hint
     except Exception:
         stats.in_peak_window, stats.peak_hint = False, ""
+
+    # Optional second provider: OpenAI Codex (opt-in via `providers` config).
+    # collect_codex serves an on-disk cache between polls, so calling it on
+    # every refresh cycle is cheap; a failure just hides the Codex rows.
+    if "codex" in (config.get("providers") or []):
+        try:
+            cx = _codex.collect_codex(
+                poll_seconds=int(config.get("codex_poll_seconds", 300) or 300))
+            stats.codex_available = bool(cx["available"])
+            stats.codex_session_utilization = float(cx["session_pct"])
+            stats.codex_session_reset = int(cx["session_reset"])
+            stats.codex_weekly_utilization = float(cx["weekly_pct"])
+            stats.codex_weekly_reset = int(cx["weekly_reset"])
+        except Exception:
+            stats.codex_available = False
 
     return stats

--- a/claude_usage/config.py
+++ b/claude_usage/config.py
@@ -40,6 +40,15 @@ DEFAULT_CONFIG: Config = {
     # budget (a low-volume endpoint shared with Claude Code).
     "refresh_seconds": 60,
 
+    # Which providers to collect. "claude" is always the primary; add "codex"
+    # to also poll the local OpenAI Codex CLI (`codex app-server`) and show
+    # its 5h/weekly rings & bars beneath Claude's. POSIX-only.
+    "providers": ["claude"],
+    # How often (seconds) to actually spawn the codex app-server RPC; between
+    # polls the on-disk cache is served. The RPC takes a couple of seconds,
+    # so keep this much larger than refresh_seconds.
+    "codex_poll_seconds": 300,
+
     # Max poll interval (seconds) the adaptive backoff climbs to when the API
     # rate-limits/errors; it snaps back to refresh_seconds on the next clean
     # refresh.

--- a/claude_usage/overlay.py
+++ b/claude_usage/overlay.py
@@ -53,6 +53,9 @@ SCOPED_ROW_HEIGHT = 31
 # stack vertically inside each column. No ticker in this view (it would
 # collide with the reset line under each ring).
 GAUGE_HEIGHT = 130
+# Extra height for the optional Codex ring row (a second Session/Weekly pair
+# drawn beneath Claude's; same stack minus the shared top padding).
+CODEX_GAUGE_ROW_HEIGHT = 118
 
 # Supported OSD view modes. Kept as string constants so config files and
 # tests don't have to import an enum.
@@ -217,6 +220,13 @@ class UsageOverlay(QWidget):
         self._scoped_pct: float = 0.0
         self._scoped_reset: int = 0
         self._scoped_label: str = ""
+        # Optional Codex provider (opt-in via `providers` config). When
+        # unavailable the OSD paints exactly as before.
+        self._codex_available: bool = False
+        self._codex_session_pct: float = 0.0
+        self._codex_session_reset: int = 0
+        self._codex_weekly_pct: float = 0.0
+        self._codex_weekly_reset: int = 0
         self._live_tpm: float = 0.0      # tokens/min over the last few minutes
         self._is_live: bool = False       # show the "● LIVE" dot
         self._burn_alert = None           # active burn/spike/storm badge (or None)
@@ -313,7 +323,17 @@ class UsageOverlay(QWidget):
         self._scoped_pct = max(0.0, min(1.0, float(getattr(stats, "scoped_utilization", 0.0))))
         self._scoped_reset = int(getattr(stats, "scoped_reset", 0) or 0)
         self._scoped_label = str(getattr(stats, "scoped_label", "") or "")
-        if bool(self._scoped_label) != had_scoped:
+        # Optional Codex provider rows — like scoped, their appearance or
+        # disappearance changes the OSD footprint.
+        had_codex = self._codex_available
+        self._codex_available = bool(getattr(stats, "codex_available", False))
+        self._codex_session_pct = max(0.0, min(1.0, float(
+            getattr(stats, "codex_session_utilization", 0.0) or 0.0)))
+        self._codex_session_reset = int(getattr(stats, "codex_session_reset", 0) or 0)
+        self._codex_weekly_pct = max(0.0, min(1.0, float(
+            getattr(stats, "codex_weekly_utilization", 0.0) or 0.0)))
+        self._codex_weekly_reset = int(getattr(stats, "codex_weekly_reset", 0) or 0)
+        if bool(self._scoped_label) != had_scoped or self._codex_available != had_codex:
             self._apply_size()
         live = getattr(stats, "live_activity", None)
         if live is not None:
@@ -462,6 +482,8 @@ class UsageOverlay(QWidget):
         width = int(BASE_WIDTH * self._scale)
         if self._view_mode == VIEW_MODE_GAUGE:
             base = GAUGE_HEIGHT + (SCOPED_ROW_HEIGHT if self._scoped_label else 0)
+            if self._codex_available:
+                base += CODEX_GAUGE_ROW_HEIGHT
         else:
             # Receipt skin always reserves the footer strip for its barcode,
             # even if the user disabled the ticker feature.
@@ -469,6 +491,8 @@ class UsageOverlay(QWidget):
             base = BASE_HEIGHT + (TICKER_STRIP_HEIGHT if wants_footer else 0)
             if self._scoped_label:
                 base += SCOPED_ROW_HEIGHT
+            if self._codex_available:
+                base += 2 * SCOPED_ROW_HEIGHT  # Codex 5h + 7d rows
         height = MINIMIZED_HEIGHT if self._minimized else int(base * self._scale)
         # Preserve the top-right corner when resizing so the overlay doesn't
         # visually drift as the user scrolls to scale.
@@ -758,45 +782,55 @@ class UsageOverlay(QWidget):
             )
 
         # Two columns splitting the panel; each column is one gauge stack.
+        # With the Codex provider active, a second row of rings (Codex 5h /
+        # 7d) is drawn beneath Claude's Session / Weekly pair.
         col_w = w / 2
         ring_d = max(50.0, min(col_w * 0.58, 80 * s))
         ring_stroke = max(4.0, 7 * s)
-        # Centre each ring inside its column, with room below for labels.
-        for idx, (label, pct, reset_ts) in enumerate((
+        ring_rows: list[tuple[tuple[str, float, int], ...]] = [(
             ("Session", self._session_pct, self._session_reset),
             ("Weekly",  self._weekly_pct,  self._weekly_reset),
-        )):
-            cx = col_w * idx + col_w / 2
-            cy = 12 * s + ring_d / 2
-            fill_color = _bar_color(pct, self._theme)
-            self._draw_ring(p, cx, cy, ring_d, ring_stroke, pct, fill_color)
+        )]
+        if self._codex_available:
+            ring_rows.append((
+                ("Codex 5h", self._codex_session_pct, self._codex_session_reset),
+                ("Codex 7d", self._codex_weekly_pct, self._codex_weekly_reset),
+            ))
+        # Centre each ring inside its column, with room below for labels.
+        for row_idx, row in enumerate(ring_rows):
+            row_top = (12 + row_idx * CODEX_GAUGE_ROW_HEIGHT) * s
+            for idx, (label, pct, reset_ts) in enumerate(row):
+                cx = col_w * idx + col_w / 2
+                cy = row_top + ring_d / 2
+                fill_color = _bar_color(pct, self._theme)
+                self._draw_ring(p, cx, cy, ring_d, ring_stroke, pct, fill_color)
 
-            # Percentage text centred in the ring.
-            pct_text = f"{int(pct * 100)}%"
-            pct_font_pt = max(10, int(13 * s))
-            p.setFont(_mono_font(pct_font_pt, bold=True))
-            p.setPen(_hex_to_qcolor(self._theme["text_primary"]))
-            fm = p.fontMetrics()
-            pct_w = fm.horizontalAdvance(pct_text)
-            p.drawText(QPointF(cx - pct_w / 2, cy + fm.ascent() / 2 - 2 * s), pct_text)
-
-            # Label + reset beneath the ring.
-            label_y = cy + ring_d / 2 + 14 * s
-            label_font_pt = max(8, int(9 * s))
-            p.setFont(_mono_font(label_font_pt, bold=True))
-            p.setPen(_hex_to_qcolor(self._theme["text_primary"]))
-            fm = p.fontMetrics()
-            lw = fm.horizontalAdvance(label)
-            p.drawText(QPointF(cx - lw / 2, label_y), label)
-
-            reset_label = _format_reset_short(reset_ts)
-            if reset_label:
-                reset_font_pt = max(7, int(7.5 * s))
-                p.setFont(_mono_font(reset_font_pt))
-                p.setPen(_hex_to_qcolor(self._theme["text_dim"]))
+                # Percentage text centred in the ring.
+                pct_text = f"{int(pct * 100)}%"
+                pct_font_pt = max(10, int(13 * s))
+                p.setFont(_mono_font(pct_font_pt, bold=True))
+                p.setPen(_hex_to_qcolor(self._theme["text_primary"]))
                 fm = p.fontMetrics()
-                rw = fm.horizontalAdvance(reset_label)
-                p.drawText(QPointF(cx - rw / 2, label_y + 12 * s), reset_label)
+                pct_w = fm.horizontalAdvance(pct_text)
+                p.drawText(QPointF(cx - pct_w / 2, cy + fm.ascent() / 2 - 2 * s), pct_text)
+
+                # Label + reset beneath the ring.
+                label_y = cy + ring_d / 2 + 14 * s
+                label_font_pt = max(8, int(9 * s))
+                p.setFont(_mono_font(label_font_pt, bold=True))
+                p.setPen(_hex_to_qcolor(self._theme["text_primary"]))
+                fm = p.fontMetrics()
+                lw = fm.horizontalAdvance(label)
+                p.drawText(QPointF(cx - lw / 2, label_y), label)
+
+                reset_label = _format_reset_short(reset_ts)
+                if reset_label:
+                    reset_font_pt = max(7, int(7.5 * s))
+                    p.setFont(_mono_font(reset_font_pt))
+                    p.setPen(_hex_to_qcolor(self._theme["text_dim"]))
+                    fm = p.fontMetrics()
+                    rw = fm.horizontalAdvance(reset_label)
+                    p.drawText(QPointF(cx - rw / 2, label_y + 12 * s), reset_label)
 
         # Burn / spike badge — centred along the top strip, which sits clear
         # above both ring tops (rings begin at y = 12·s; the gauge draws no
@@ -989,6 +1023,20 @@ class UsageOverlay(QWidget):
                 reset_label=_format_reset_short(self._scoped_reset),
             )
             y2 = y3  # push the footer below the extra row
+
+        # --- Codex provider rows — only when the codex provider is active ---
+        if self._codex_available:
+            for label, pct, reset_ts in (
+                ("Codex 5h", self._codex_session_pct, self._codex_session_reset),
+                ("Codex 7d", self._codex_weekly_pct, self._codex_weekly_reset),
+            ):
+                y2 = y2 + 15 * s + bar_h + 10 * s
+                self._draw_row(
+                    p, y2, w, pad_x, bar_w, bar_h, bar_r, font_label, font_small,
+                    label=label,
+                    pct=pct,
+                    reset_label=_format_reset_short(reset_ts),
+                )
 
         # --- Ticker strip / receipt footer (below the weekly row) ---
         # Receipt skin replaces the scrolling ticker with a dotted

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1,0 +1,64 @@
+"""Tests for the opt-in Codex provider (claude_usage.codex)."""
+
+import time
+
+from claude_usage.codex import _clamp_expired, parse_rate_limits
+
+
+FUTURE = int(time.time()) + 3600
+
+
+def _payload(primary=None, secondary=None):
+    limits = {}
+    if primary is not None:
+        limits["primary"] = primary
+    if secondary is not None:
+        limits["secondary"] = secondary
+    return {"rateLimits": limits}
+
+
+def test_parse_both_windows():
+    parsed = parse_rate_limits(_payload(
+        primary={"usedPercent": 54.2, "resetsAt": FUTURE, "windowDurationMins": 300},
+        secondary={"usedPercent": 12.0, "resetsAt": FUTURE + 86400},
+    ))
+    assert parsed == {
+        "session_pct": 0.542,
+        "session_reset": FUTURE,
+        "weekly_pct": 0.12,
+        "weekly_reset": FUTURE + 86400,
+    }
+
+
+def test_parse_single_window_and_clamping():
+    parsed = parse_rate_limits(_payload(primary={"usedPercent": 250.0, "resetsAt": None}))
+    assert parsed is not None
+    assert parsed["session_pct"] == 1.0  # clamped to 0..1
+    assert parsed["session_reset"] == 0
+    assert parsed["weekly_pct"] == 0.0
+
+
+def test_parse_millisecond_resets_normalised():
+    parsed = parse_rate_limits(_payload(primary={"usedPercent": 10, "resetsAt": FUTURE * 1000}))
+    assert parsed is not None
+    assert parsed["session_reset"] == FUTURE
+
+
+def test_parse_rejects_unusable_payloads():
+    assert parse_rate_limits(None) is None
+    assert parse_rate_limits({}) is None
+    assert parse_rate_limits({"rateLimits": "nope"}) is None
+    assert parse_rate_limits(_payload()) is None
+    assert parse_rate_limits(_payload(primary={"usedPercent": None})) is None
+    assert parse_rate_limits(_payload(primary={"usedPercent": "NaN%"})) is None
+
+
+def test_clamp_expired_windows_roll_back_to_zero():
+    now = time.time()
+    parsed = {
+        "session_pct": 0.9, "session_reset": int(now - 60),
+        "weekly_pct": 0.4, "weekly_reset": int(now + 3600),
+    }
+    out = _clamp_expired(parsed, now)
+    assert out["session_pct"] == 0.0 and out["session_reset"] == 0
+    assert out["weekly_pct"] == 0.4 and out["weekly_reset"] == int(now + 3600)


### PR DESCRIPTION
Implements #17 — went ahead with a working implementation so there's something concrete to reshape; happy to adjust to whichever design you prefer.

## What

Add `"codex"` to a new `providers` config key (default `["claude"]`) and the widget also shows the local OpenAI Codex CLI's rate limits: a second ring row (**Codex 5h** / **Codex 7d**) in gauge view, two extra bars in bars view.

*(Layout: 2×2 ring grid — Claude Session/Weekly on top, Codex 5h/7d below; the scoped bar stays at the bottom. Screenshot available on request.)*

## How

- **Data**: `codex app-server` JSON-RPC over stdio (`initialize` → `initialized` → `account/rateLimits/read`) returns `rateLimits.primary/secondary` with `usedPercent`/`resetsAt` — same shape as Claude's session/weekly pair, rendered with the existing ring/bar primitives.
- **Cost control**: the RPC spawn takes a couple of seconds, so it's throttled by `codex_poll_seconds` (default 300 s) with an on-disk cache served in between; on RPC failure the cache is served, and windows whose reset has passed are clamped to zero — mirroring your Claude sample-fallback path in `collect_all`.
- **Zero default impact**: with the default `providers`, no RPC is ever spawned and the OSD paints pixel-identical to today. The rows also auto-hide when the codex CLI is missing or logged out (same auto-appear/hide contract as the scoped weekly row). POSIX-only for now (the reader uses `select` on pipes); non-POSIX reports unavailable.
- **Skins**: left Claude-only in this PR — per #17, I'd add either a generic `extra_rows` on `SkinData` or codex-specific fields once you pick a shape.

## Testing

- `pytest tests/`: 439 passed (adds `tests/test_codex.py` covering the RPC payload parser: both/single windows, percent clamping, ms-vs-s reset normalisation, unusable payloads, expired-window clamping).
- Live-verified on macOS against a real Codex subscription: rings show the same numbers as `codex`'s own status output, cache behaviour and auto-hide (binary removed from PATH) both exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
