### PR TITLE
Add a single-instance guard to the GUI launch path

### DIFF
--- a/claude_usage/cli.py
+++ b/claude_usage/cli.py
@@ -12,12 +12,17 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 from dataclasses import asdict, is_dataclass
 from typing import Sequence
 
 from claude_usage import __version__
 from claude_usage.collector import UsageStats, collect_all
 from claude_usage.config import load_config, user_config_path
+
+# Holds the QLockFile for the GUI's single-instance guard; assigned in
+# _launch_gui and kept alive for the process lifetime.
+_instance_lock = None
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -256,10 +261,22 @@ def _launch_gui() -> None:
     if sys.platform.startswith("linux"):
         os.environ.setdefault("QT_QPA_PLATFORM", "xcb")
 
-    from PySide6.QtCore import Qt
+    from PySide6.QtCore import Qt, QLockFile
     from PySide6.QtWidgets import QApplication
 
     from claude_usage.widget import ClaudeUsageApp
+
+    # Single-instance guard — repeated launches (login items, scripts, retry
+    # loops) otherwise stack identical OSDs on top of each other. QLockFile
+    # detects and removes locks left behind by crashed processes, so a hard
+    # kill never wedges future launches. The lock must outlive this function,
+    # hence the module-level reference.
+    global _instance_lock
+    _instance_lock = QLockFile(
+        os.path.join(tempfile.gettempdir(), "claude-usage-widget.lock"))
+    if not _instance_lock.tryLock(100):
+        print("claude-usage is already running; exiting.", file=sys.stderr)
+        sys.exit(0)
 
     # High-DPI is default in Qt 6; no special attribute needed.
     try:


### PR DESCRIPTION
## Problem

Launching `claude-usage` while it's already running silently stacks a second identical always-on-top OSD over the first (and a third, and…). Each instance also polls the usage API on its own timer. Easy to hit via login items, scripts, or plain double-launching — I managed to stack five before noticing.

## Fix

Guard the GUI entry point (`_launch_gui`) with a `QLockFile` in the temp dir. A second launch prints `claude-usage is already running; exiting.` to stderr and exits 0. QLockFile detects and removes locks left behind by crashed processes (PID-based staleness), so a hard kill never wedges future launches. CLI modes (`--once`, `--json`, `--statusline`, …) are unaffected.

## Testing

- `pytest tests/`: 439 passed, no changes needed.
- Manual on macOS: triple-launched `claude-usage --detach` — exactly one process survives; `kill -9` the survivor, relaunch works immediately (stale lock reclaimed).

Independent of #18 (touches only `cli.py`); no conflict whichever lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)