### PR TITLE
statusLine-fed rate limits: zero-cost freshness + endpoint quota relief

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,27 @@ python3 main.py
 - **claude-usage v`<version>`** -- a dim, disabled line showing the running build's version; when a newer release is published an **↑ Update available: `<tag>`** item appears above it (click to copy the `pip install --upgrade` command)
 - **Quit** -- exit the widget
 
+## Statusline-fed rate limits
+
+If your Claude Code `statusLine` command dumps its rate-limit payload to a JSON file, the widget can use it as a zero-cost data source — Claude Code rewrites the statusline continuously during an active session, so the file carries the same numbers as `/api/oauth/usage` at seconds freshness and no API spend. Point `statusline_cache_path` at a file shaped like:
+
+```json
+{
+  "captured_at": "2026-07-11T22:52:05+09:00",
+  "rate_limits": {
+    "five_hour": {"used_percentage": 54, "resets_at": 1783795800},
+    "seven_day": {"used_percentage": 46, "resets_at": 1784026800}
+  }
+}
+```
+
+With this configured the widget uses it two ways:
+
+- **Endpoint relief** — while the dump is younger than `2 × refresh_seconds`, the `/api/oauth/usage` call is skipped and only forced through at most once per `usage_endpoint_min_seconds`. The endpoint is a low-budget resource shared with Claude Code itself; the forced calls keep the model-scoped/overage fields fresh and pick up consumption from headless `claude -p` runs, which never render a statusline.
+- **Rate-limit fallback** — when the endpoint throttles us, a dump younger than 20 minutes beats the last on-disk sample, which can lag a whole rate-limit window behind.
+
+Producing the file is up to your statusline script (it receives the payload from Claude Code on stdin and can `tee` the relevant part out). Expired windows in a stale dump are clamped to zero, and a missing/garbled file just disables the feature for that refresh.
+
 ## Configuration
 
 All settings are optional. Copy `config.json.example` to `config.json` and edit the values you want to change:
@@ -208,6 +229,8 @@ cp config.json.example config.json
 |---------|---------|-------------|
 | `refresh_seconds` | `60` | Base poll interval — how often to fetch new data from the API (seconds) |
 | `refresh_max_seconds` | `300` | Max poll interval when the API rate-limits/errors; the interval backs off exponentially toward this cap and snaps back to `refresh_seconds` on the next clean refresh |
+| `statusline_cache_path` | `""` | Path to a statusLine-dumped rate-limit JSON file (see [Statusline-fed rate limits](#statusline-fed-rate-limits)). Empty = disabled. |
+| `usage_endpoint_min_seconds` | `300` | With `statusline_cache_path` set: while the dump is seconds-fresh, `/api/oauth/usage` is called at most once per this many seconds. |
 | `osd_opacity` | `0.75` | OSD background opacity (0.15--1.0) |
 | `osd_scale` | `1.0` | OSD scale factor (0.6--2.0) |
 | `daily_message_limit` | `200` | Daily message limit for local tracking in the popup |

--- a/claude_usage/collector.py
+++ b/claude_usage/collector.py
@@ -910,6 +910,51 @@ def _parse_rate_limit_headers(headers: dict[str, str]) -> dict[str, Any]:
     }
 
 
+STATUSLINE_CACHE_MAX_AGE_SECONDS = 20 * 60
+
+
+def _load_statusline_rate_limits(
+    config: dict[str, Any],
+    now_ts: float,
+    max_age_seconds: float = STATUSLINE_CACHE_MAX_AGE_SECONDS,
+) -> dict[str, tuple[float, int]] | None:
+    """Read a statusLine-dumped rate-limit file (see `statusline_cache_path`).
+
+    Returns ``{"session": (pct, reset_ts), "weekly": (pct, reset_ts)}`` with
+    expired windows clamped to zero, or None when the feature is disabled,
+    the file is missing/older than ``max_age_seconds``/from the future, or
+    either window is absent.
+    """
+    path = str(config.get("statusline_cache_path", "") or "")
+    if not path:
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        captured = datetime.fromisoformat(str(data["captured_at"])).timestamp()
+        age = now_ts - captured
+        if age > max_age_seconds or age < -300:
+            return None
+        limits = data["rate_limits"]
+
+        def window(block: Any) -> tuple[float, int] | None:
+            if not isinstance(block, dict) or block.get("used_percentage") is None:
+                return None
+            pct = max(0.0, min(1.0, float(block["used_percentage"]) / 100.0))
+            reset = int(block.get("resets_at") or 0)
+            if reset and now_ts >= reset:  # window rolled over since capture
+                return 0.0, 0
+            return pct, reset
+
+        session = window(limits.get("five_hour"))
+        weekly = window(limits.get("seven_day"))
+        if session is None or weekly is None:
+            return None
+        return {"session": session, "weekly": weekly}
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+
+
 def collect_all(config: dict[str, Any]) -> UsageStats:
     """Collect all usage stats from local ``~/.claude/`` files and the Anthropic API.
 
@@ -959,10 +1004,48 @@ def collect_all(config: dict[str, Any]) -> UsageStats:
 
     stats.active_sessions = get_active_sessions(claude_dir)
 
-    rate_limits = fetch_rate_limits(claude_dir)
     now_ts = datetime.now().timestamp()
 
-    if "error" in rate_limits:
+    # Endpoint relief: when a statusLine dump is seconds-fresh, the endpoint
+    # has nothing newer to say about the session/weekly pair — skip the call
+    # and spend its budget at most once per `usage_endpoint_min_seconds`
+    # (scoped/overage data, and consumption from headless `claude -p` runs
+    # that never render a statusline, still need the real endpoint).
+    # `samples_path`'s mtime records the last *successful* endpoint fetch:
+    # append_sample/prune only run in the success branch below, and the
+    # statusline/skip paths deliberately never touch the file.
+    sl_live = _load_statusline_rate_limits(
+        config, now_ts,
+        max_age_seconds=2 * int(config.get("refresh_seconds", 60) or 60))
+    endpoint_min = int(config.get("usage_endpoint_min_seconds", 300) or 300)
+    try:
+        last_fetch_ts = os.path.getmtime(samples_path)
+    except OSError:
+        last_fetch_ts = 0.0
+    if sl_live is not None and (now_ts - last_fetch_ts) < endpoint_min:
+        stats.session_utilization, stats.session_reset = sl_live["session"]
+        stats.weekly_utilization, stats.weekly_reset = sl_live["weekly"]
+        # Scoped cap isn't in the statusline payload — carry the last
+        # sampled triple forward, clamping an expired window to zero.
+        try:
+            recent = load_samples(samples_path)
+        except OSError:
+            recent = []
+        for prev in reversed(recent):
+            if prev.get("scoped_label"):
+                scoped_reset = int(prev.get("scoped_reset", 0) or 0)
+                if not scoped_reset or now_ts < scoped_reset:
+                    stats.scoped_label = str(prev["scoped_label"])
+                    stats.scoped_utilization = float(prev.get("scoped", 0.0) or 0.0)
+                    stats.scoped_reset = scoped_reset
+                break
+        rate_limits = None
+    else:
+        rate_limits = fetch_rate_limits(claude_dir)
+
+    if rate_limits is None:
+        pass
+    elif "error" in rate_limits:
         stats.rate_limit_error = rate_limits["error"]
         # API call failed (transient network glitch, OAuth hiccup, etc.).
         # Without this, both utilization fields stay at the dataclass
@@ -1020,6 +1103,16 @@ def collect_all(config: dict[str, Any]) -> UsageStats:
             stats.scoped_utilization = scoped_util
             stats.scoped_reset = scoped_reset
             stats.scoped_label = scoped_label
+        # Fresher zero-cost source: a statusLine-dumped rate-limit file (see
+        # `statusline_cache_path` in config). Claude Code pushes it on every
+        # statusline render, so while the user is in a session it's seconds
+        # old — beats the last sample, which can lag a whole rate-limit
+        # window behind. Overrides session/weekly only; scoped stays on the
+        # sample fallback (the statusline payload doesn't carry it).
+        sl = _load_statusline_rate_limits(config, now_ts)
+        if sl is not None:
+            stats.session_utilization, stats.session_reset = sl["session"]
+            stats.weekly_utilization, stats.weekly_reset = sl["weekly"]
     else:
         stats.session_utilization = rate_limits["session_utilization"]
         stats.session_reset = rate_limits["session_reset"]

--- a/claude_usage/config.py
+++ b/claude_usage/config.py
@@ -45,6 +45,21 @@ DEFAULT_CONFIG: Config = {
     # refresh.
     "refresh_max_seconds": 300,
 
+    # Optional path to a JSON file a Claude Code statusLine command dumps its
+    # rate-limit payload to ({"captured_at": iso, "rate_limits": {"five_hour":
+    # {"used_percentage", "resets_at"}, "seven_day": {...}}}). Claude Code
+    # re-renders the statusline continuously during an active session, so a
+    # fresh copy of this file carries the same numbers as /api/oauth/usage at
+    # zero API cost. Empty = disabled; see "Statusline-fed rate limits" in
+    # the README.
+    "statusline_cache_path": "",
+    # With statusline_cache_path set: while the dump is seconds-fresh, skip
+    # the /api/oauth/usage call and only hit the endpoint at most once per
+    # this many seconds — it is a low-budget endpoint shared with Claude
+    # Code, and the scoped/overage fields plus headless (`claude -p`)
+    # consumption are all it's still needed for.
+    "usage_endpoint_min_seconds": 300,
+
     # Opacity of the floating OSD overlay window (0.0 = fully transparent,
     # 1.0 = fully opaque).  0.75 keeps it readable without obscuring content.
     "osd_opacity": 0.75,

--- a/tests/test_statusline_source.py
+++ b/tests/test_statusline_source.py
@@ -1,0 +1,83 @@
+"""Tests for the statusLine-dumped rate-limit source (claude_usage.collector)."""
+
+import json
+import time
+from datetime import datetime, timezone
+
+from claude_usage.collector import _load_statusline_rate_limits
+
+
+NOW = time.time()
+FUTURE = int(NOW) + 3600
+
+
+def _write(tmp_path, captured_at=None, five_hour=..., seven_day=...):
+    if captured_at is None:
+        captured_at = datetime.now(timezone.utc).isoformat()
+    limits = {}
+    if five_hour is not ...:
+        limits["five_hour"] = five_hour
+    if seven_day is not ...:
+        limits["seven_day"] = seven_day
+    path = tmp_path / "statusline.json"
+    path.write_text(json.dumps({"captured_at": captured_at, "rate_limits": limits}))
+    return str(path)
+
+
+def _cfg(path):
+    return {"statusline_cache_path": path}
+
+
+def test_fresh_file_both_windows(tmp_path):
+    path = _write(
+        tmp_path,
+        five_hour={"used_percentage": 54, "resets_at": FUTURE},
+        seven_day={"used_percentage": 46, "resets_at": FUTURE + 86400},
+    )
+    out = _load_statusline_rate_limits(_cfg(path), NOW)
+    assert out == {
+        "session": (0.54, FUTURE),
+        "weekly": (0.46, FUTURE + 86400),
+    }
+
+
+def test_expired_window_clamps_to_zero(tmp_path):
+    path = _write(
+        tmp_path,
+        five_hour={"used_percentage": 90, "resets_at": int(NOW) - 60},
+        seven_day={"used_percentage": 46, "resets_at": FUTURE},
+    )
+    out = _load_statusline_rate_limits(_cfg(path), NOW)
+    assert out is not None
+    assert out["session"] == (0.0, 0)
+    assert out["weekly"] == (0.46, FUTURE)
+
+
+def test_stale_and_future_files_rejected(tmp_path):
+    old = datetime.fromtimestamp(NOW - 3600, tz=timezone.utc).isoformat()
+    path = _write(tmp_path, captured_at=old,
+                  five_hour={"used_percentage": 10, "resets_at": FUTURE},
+                  seven_day={"used_percentage": 10, "resets_at": FUTURE})
+    assert _load_statusline_rate_limits(_cfg(path), NOW) is None
+    # But a caller-supplied larger max age accepts it:
+    assert _load_statusline_rate_limits(_cfg(path), NOW, max_age_seconds=7200) is not None
+    ahead = datetime.fromtimestamp(NOW + 3600, tz=timezone.utc).isoformat()
+    path = _write(tmp_path, captured_at=ahead,
+                  five_hour={"used_percentage": 10, "resets_at": FUTURE},
+                  seven_day={"used_percentage": 10, "resets_at": FUTURE})
+    assert _load_statusline_rate_limits(_cfg(path), NOW) is None
+
+
+def test_missing_window_or_file_or_config_rejected(tmp_path):
+    path = _write(tmp_path, five_hour={"used_percentage": 10, "resets_at": FUTURE})
+    assert _load_statusline_rate_limits(_cfg(path), NOW) is None
+    assert _load_statusline_rate_limits(_cfg(str(tmp_path / "nope.json")), NOW) is None
+    assert _load_statusline_rate_limits({}, NOW) is None
+
+
+def test_garbage_payload_rejected(tmp_path):
+    path = tmp_path / "statusline.json"
+    path.write_text("not json {")
+    assert _load_statusline_rate_limits(_cfg(str(path)), NOW) is None
+    path.write_text(json.dumps({"captured_at": "yesterday-ish", "rate_limits": {}}))
+    assert _load_statusline_rate_limits(_cfg(str(path)), NOW) is None


### PR DESCRIPTION
## Idea

A Claude Code `statusLine` command receives the rate-limit payload on every render — during an active session that's a seconds-fresh copy of exactly what `/api/oauth/usage` would return, at zero API cost. If the user's statusline script tees it into a JSON file, the widget can drink from it.

New `statusline_cache_path` config (default `""` = off, behaviour-identical for existing users) uses the file two ways:

1. **Endpoint relief** — while the dump is younger than `2 × refresh_seconds`, the widget skips the `/api/oauth/usage` call entirely, forcing a real one at most once per `usage_endpoint_min_seconds` (default 300 s). The endpoint is a low-budget resource shared with Claude Code itself — I got throttled hard enough during testing that the OSD sat on stale numbers for half an hour, which is what motivated this. The forced periodic call still keeps the model-scoped/overage fields fresh and picks up consumption from headless `claude -p` runs (those never render a statusline, so statusline data alone can't see them — that's also why this can't simply replace the endpoint).
2. **Rate-limit fallback** — when the endpoint does throttle, a dump younger than 20 min beats the last on-disk sample, which can lag a whole rate-limit window behind (session showing a pre-reset percentage after the 5h window rolled over, etc.).

## Design notes

- The samples file's mtime doubles as the "last successful endpoint fetch" marker — `append_sample`/`prune` only run in the success branch, and the skip/fallback paths deliberately never touch the file, so no new state file is needed.
- Expired windows in the dump are clamped to zero (same semantics as the existing sample fallback). Missing/stale/garbled/future-dated files just disable the feature for that refresh.
- The expected file shape is documented in a new README section (`captured_at` + `rate_limits.five_hour/seven_day` with `used_percentage`/`resets_at`); producing it is a 3-line addition to any statusline script.

## Testing

- `pytest tests/`: 439 passed (new `tests/test_statusline_source.py`: fresh/expired/stale/future/missing/garbage cases).
- Live on macOS: verified all three paths against a real account — skip path (fresh dump + recent fetch → no endpoint call, correct numbers, scoped carried forward), fallback path (during an actual rate-limit episode the OSD tracked the statusline values instead of a stale sample), and normal path (endpoint healthy → identical to today, cross-checked statusline vs endpoint values agree within one refresh).

Independent of #18/#19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)