### PR TITLE
Show Codex 5h/7d rows in the self-drawn OSD skins

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ cp config.json.example config.json
 | `refresh_seconds` | `60` | Base poll interval — how often to fetch new data from the API (seconds) |
 | `refresh_max_seconds` | `300` | Max poll interval when the API rate-limits/errors; the interval backs off exponentially toward this cap and snaps back to `refresh_seconds` on the next clean refresh |
 | `osd_opacity` | `0.75` | OSD background opacity (0.15--1.0) |
-| `osd_scale` | `1.0` | OSD scale factor (0.6--2.0) |
+| `osd_scale` | `1.0` | OSD scale factor (0.6--4.0) |
+| `providers` | `["claude"]` | Add `"codex"` to also poll the local OpenAI Codex CLI (`codex app-server`) and show its 5h/weekly usage beneath Claude's — an extra ring row in gauge view, two extra bars in bars view. POSIX-only. |
+| `codex_poll_seconds` | `300` | How often (seconds) to spawn the codex app-server RPC; an on-disk cache is served in between. |
 | `daily_message_limit` | `200` | Daily message limit for local tracking in the popup |
 | `weekly_message_limit` | `1000` | Weekly message limit for local tracking in the popup |
 | `daily_token_limit` | `5000000` | Daily token limit for local tracking |
@@ -220,7 +222,7 @@ cp config.json.example config.json
 | `show_news` | `false` | Whether the live Anthropic/Claude news headline strip is shown on the OSD. Off by default because it makes outbound calls to a 3rd-party feed. Toggle at runtime via right-click → "Show news ticker". |
 | `osd_position` | `top-right` | Where the OSD anchors: `top-left`, `top-right`, `bottom-left`, `bottom-right`, or `custom`. Set from right-click → "OSD Position", or automatically to `custom` when you drag the overlay. |
 | `osd_x` / `osd_y` | `null` | Exact screen coordinates used only when `osd_position` is `custom`. Written automatically on drag. |
-| `osd_scale` | `1.0` | OSD zoom level (0.6–2.0). Updated automatically when you scroll the mouse wheel over the OSD, so it reopens at the same size. |
+| `osd_scale` | `1.0` | OSD zoom level (0.6–4.0). Updated automatically when you scroll the mouse wheel over the OSD, so it reopens at the same size. |
 | `osd_minimized` | `false` | Whether the OSD is in its collapsed thin-strip form. Written automatically via right-click → "Minimize / Restore". |
 | `osd_visible` | `true` | Whether the OSD overlay is shown. Written on quit so the widget reopens in the same visible/hidden state. |
 | `osd_always_on_top` | `true` | Keep the OSD pinned above other windows. Set to `false` (or right-click → "Always on top") to let it sit as a normal background desktop widget. |

--- a/claude_usage/cli.py
+++ b/claude_usage/cli.py
@@ -12,12 +12,17 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 from dataclasses import asdict, is_dataclass
 from typing import Sequence
 
 from claude_usage import __version__
 from claude_usage.collector import UsageStats, collect_all
 from claude_usage.config import load_config, user_config_path
+
+# Holds the QLockFile for the GUI's single-instance guard; assigned in
+# _launch_gui and kept alive for the process lifetime.
+_instance_lock = None
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -256,10 +261,22 @@ def _launch_gui() -> None:
     if sys.platform.startswith("linux"):
         os.environ.setdefault("QT_QPA_PLATFORM", "xcb")
 
-    from PySide6.QtCore import Qt
+    from PySide6.QtCore import Qt, QLockFile
     from PySide6.QtWidgets import QApplication
 
     from claude_usage.widget import ClaudeUsageApp
+
+    # Single-instance guard — repeated launches (login items, scripts, retry
+    # loops) otherwise stack identical OSDs on top of each other. QLockFile
+    # detects and removes locks left behind by crashed processes, so a hard
+    # kill never wedges future launches. The lock must outlive this function,
+    # hence the module-level reference.
+    global _instance_lock
+    _instance_lock = QLockFile(
+        os.path.join(tempfile.gettempdir(), "claude-usage-widget.lock"))
+    if not _instance_lock.tryLock(100):
+        print("claude-usage is already running; exiting.", file=sys.stderr)
+        sys.exit(0)
 
     # High-DPI is default in Qt 6; no special attribute needed.
     try:

--- a/claude_usage/codex.py
+++ b/claude_usage/codex.py
@@ -1,0 +1,220 @@
+"""OpenAI Codex rate-limit collector (opt-in second provider).
+
+Talks to the local ``codex`` CLI's ``app-server`` over stdio JSON-RPC:
+``initialize`` -> ``initialized`` -> ``account/rateLimits/read``. The
+response carries a ``rateLimits`` object with a ``primary`` (~5h) and
+``secondary`` (weekly) window, each with ``usedPercent`` and ``resetsAt``
+— the same shape as Claude's session/weekly pair, so the overlay can
+render them with the exact same ring/bar primitives.
+
+Spawning the app-server takes a couple of seconds, so results are cached
+on disk (`~/.cache/claude-usage/codex_limits.json`) and only refreshed
+every ``poll_seconds``. Between polls — and on RPC failure — the cache is
+served, with expired windows clamped back to zero exactly like the Claude
+sample-fallback path in ``collector.collect_all``.
+
+POSIX-only for now: the reader uses ``select`` on pipes, which does not
+work on Windows. On other platforms ``collect_codex`` reports
+unavailable and the UI simply never shows the Codex rows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import select
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+RPC_TIMEOUT_SECONDS = 12
+DEFAULT_POLL_SECONDS = 300
+CACHE_PATH = Path.home() / ".cache" / "claude-usage" / "codex_limits.json"
+_BIN_CANDIDATES = ("/opt/homebrew/bin/codex", "/usr/local/bin/codex")
+
+
+def find_codex_bin() -> str | None:
+    """Locate the ``codex`` CLI, preferring whatever is on PATH."""
+    which = shutil.which("codex")
+    if which:
+        return which
+    for candidate in _BIN_CANDIDATES:
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def _rate_limits_rpc(codex_bin: str, timeout: float = RPC_TIMEOUT_SECONDS) -> dict[str, Any] | None:
+    """Run one ``account/rateLimits/read`` round-trip against ``codex app-server``."""
+    proc = subprocess.Popen(
+        [codex_bin, "app-server"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+
+    def send(obj: dict[str, Any]) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(obj) + "\n")
+        proc.stdin.flush()
+
+    result: dict[str, Any] | None = None
+    try:
+        send({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"clientInfo": {
+                "name": "claude-usage-widget",
+                "title": "Claude Usage Widget",
+                "version": "0",
+            }},
+        })
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline and result is None:
+            assert proc.stdout is not None
+            ready, _, _ = select.select(
+                [proc.stdout], [], [], max(0.0, deadline - time.monotonic()))
+            if not ready:
+                break
+            line = proc.stdout.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line)
+            except ValueError:
+                continue
+            if msg.get("id") == 1:
+                send({"jsonrpc": "2.0", "method": "initialized"})
+                # The app-server needs a beat between the handshake and the
+                # first real request or it drops it on the floor.
+                time.sleep(0.6)
+                send({"jsonrpc": "2.0", "id": 2,
+                      "method": "account/rateLimits/read", "params": {}})
+            elif msg.get("id") == 2:
+                result = msg.get("result")
+    finally:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+    return result
+
+
+def parse_rate_limits(payload: Any) -> dict[str, Any] | None:
+    """Extract the two utilization windows from a rateLimits/read result.
+
+    Returns ``{"session_pct", "session_reset", "weekly_pct", "weekly_reset"}``
+    (pct 0..1, reset as unix seconds, 0 when absent), or None when the
+    payload has no usable window data.
+    """
+    if not isinstance(payload, dict):
+        return None
+    limits = payload.get("rateLimits")
+    if not isinstance(limits, dict):
+        return None
+
+    def window(block: Any) -> tuple[float, int] | None:
+        if not isinstance(block, dict) or block.get("usedPercent") is None:
+            return None
+        try:
+            pct = max(0.0, min(1.0, float(block["usedPercent"]) / 100.0))
+        except (TypeError, ValueError):
+            return None
+        reset = block.get("resetsAt")
+        try:
+            reset_ts = int(reset) if reset is not None else 0
+        except (TypeError, ValueError):
+            reset_ts = 0
+        if reset_ts > 10**12:  # milliseconds — normalise to seconds
+            reset_ts //= 1000
+        return pct, reset_ts
+
+    primary = window(limits.get("primary"))
+    secondary = window(limits.get("secondary"))
+    if primary is None and secondary is None:
+        return None
+    return {
+        "session_pct": primary[0] if primary else 0.0,
+        "session_reset": primary[1] if primary else 0,
+        "weekly_pct": secondary[0] if secondary else 0.0,
+        "weekly_reset": secondary[1] if secondary else 0,
+    }
+
+
+def _load_cache() -> dict[str, Any] | None:
+    try:
+        with open(CACHE_PATH, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def _save_cache(payload: dict[str, Any]) -> None:
+    try:
+        CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = CACHE_PATH.with_suffix(".tmp")
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump({"fetched_at": time.time(), "payload": payload}, fh)
+        os.replace(tmp, CACHE_PATH)
+    except OSError:
+        pass
+
+
+def _clamp_expired(parsed: dict[str, Any], now_ts: float) -> dict[str, Any]:
+    """A window whose reset has passed has rolled over — show 0, not stale %."""
+    out = dict(parsed)
+    if out["session_reset"] and now_ts >= out["session_reset"]:
+        out["session_pct"], out["session_reset"] = 0.0, 0
+    if out["weekly_reset"] and now_ts >= out["weekly_reset"]:
+        out["weekly_pct"], out["weekly_reset"] = 0.0, 0
+    return out
+
+
+def collect_codex(poll_seconds: int = DEFAULT_POLL_SECONDS) -> dict[str, Any]:
+    """Return Codex utilization for the overlay; never raises.
+
+    ``{"available": bool, "session_pct", "session_reset", "weekly_pct",
+    "weekly_reset", "error": str}`` — available=False hides the Codex UI.
+    """
+    unavailable = {
+        "available": False, "error": "",
+        "session_pct": 0.0, "session_reset": 0,
+        "weekly_pct": 0.0, "weekly_reset": 0,
+    }
+    if os.name != "posix":
+        return {**unavailable, "error": "codex provider is POSIX-only for now"}
+    codex_bin = find_codex_bin()
+    if codex_bin is None:
+        return {**unavailable, "error": "codex binary not found"}
+
+    now_ts = time.time()
+    cache = _load_cache()
+    if cache is not None:
+        age = now_ts - float(cache.get("fetched_at", 0) or 0)
+        parsed = parse_rate_limits(cache.get("payload"))
+        if parsed is not None and 0 <= age < poll_seconds:
+            return {"available": True, "error": "", **_clamp_expired(parsed, now_ts)}
+
+    payload = None
+    try:
+        payload = _rate_limits_rpc(codex_bin)
+    except OSError:
+        payload = None
+    parsed = parse_rate_limits(payload)
+    if parsed is not None:
+        assert isinstance(payload, dict)
+        _save_cache(payload)
+        return {"available": True, "error": "", **_clamp_expired(parsed, now_ts)}
+
+    # RPC failed — fall back to any cache, however old, before giving up.
+    if cache is not None:
+        parsed = parse_rate_limits(cache.get("payload"))
+        if parsed is not None:
+            return {"available": True, "error": "rpc failed; serving cache",
+                    **_clamp_expired(parsed, now_ts)}
+    return {**unavailable, "error": "rateLimits/read returned no window data"}

--- a/claude_usage/collector.py
+++ b/claude_usage/collector.py
@@ -919,6 +919,48 @@ def _parse_rate_limit_headers(headers: dict[str, str]) -> dict[str, Any]:
     }
 
 
+STATUSLINE_CACHE_MAX_AGE_SECONDS = 20 * 60
+
+
+def _load_statusline_rate_limits(
+    config: dict[str, Any], now_ts: float
+) -> dict[str, tuple[float, int]] | None:
+    """Read a statusLine-dumped rate-limit file (see `statusline_cache_path`).
+
+    Returns ``{"session": (pct, reset_ts), "weekly": (pct, reset_ts)}`` with
+    expired windows clamped to zero, or None when the feature is disabled,
+    the file is missing/stale/from the future, or either window is absent.
+    """
+    path = str(config.get("statusline_cache_path", "") or "")
+    if not path:
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        captured = datetime.fromisoformat(str(data["captured_at"])).timestamp()
+        age = now_ts - captured
+        if age > STATUSLINE_CACHE_MAX_AGE_SECONDS or age < -300:
+            return None
+        limits = data["rate_limits"]
+
+        def window(block: Any) -> tuple[float, int] | None:
+            if not isinstance(block, dict) or block.get("used_percentage") is None:
+                return None
+            pct = max(0.0, min(1.0, float(block["used_percentage"]) / 100.0))
+            reset = int(block.get("resets_at") or 0)
+            if reset and now_ts >= reset:  # window rolled over since capture
+                return 0.0, 0
+            return pct, reset
+
+        session = window(limits.get("five_hour"))
+        weekly = window(limits.get("seven_day"))
+        if session is None or weekly is None:
+            return None
+        return {"session": session, "weekly": weekly}
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+
+
 def collect_all(config: dict[str, Any]) -> UsageStats:
     """Collect all usage stats from local ``~/.claude/`` files and the Anthropic API.
 
@@ -1029,6 +1071,16 @@ def collect_all(config: dict[str, Any]) -> UsageStats:
             stats.scoped_utilization = scoped_util
             stats.scoped_reset = scoped_reset
             stats.scoped_label = scoped_label
+        # Fresher zero-cost source: a statusLine-dumped rate-limit file (see
+        # `statusline_cache_path` in config). Claude Code pushes it on every
+        # statusline render, so while the user is in a session it's seconds
+        # old — beats the last sample, which can lag a whole rate-limit
+        # window behind. Overrides session/weekly only; scoped stays on the
+        # sample fallback (the statusline payload doesn't carry it).
+        sl = _load_statusline_rate_limits(config, now_ts)
+        if sl is not None:
+            stats.session_utilization, stats.session_reset = sl["session"]
+            stats.weekly_utilization, stats.weekly_reset = sl["weekly"]
     else:
         stats.session_utilization = rate_limits["session_utilization"]
         stats.session_reset = rate_limits["session_reset"]

--- a/claude_usage/collector.py
+++ b/claude_usage/collector.py
@@ -19,6 +19,7 @@ from urllib.request import Request, urlopen
 
 from claude_usage import forecast, pricing
 from claude_usage import budget as _budget
+from claude_usage import codex as _codex
 from claude_usage import peak as _peak
 from claude_usage.analytics import AnomalyReport, detect_anomaly, generate_tips
 from claude_usage.burn import (
@@ -78,6 +79,14 @@ class UsageStats:
     scoped_utilization: float = 0.0
     scoped_reset: int = 0
     scoped_label: str = ""
+    # Optional second provider: OpenAI Codex rate limits, populated only when
+    # "codex" is listed in the `providers` config key. codex_available=False
+    # means the overlay draws no Codex rows at all.
+    codex_available: bool = False
+    codex_session_utilization: float = 0.0
+    codex_session_reset: int = 0
+    codex_weekly_utilization: float = 0.0
+    codex_weekly_reset: int = 0
     overage_status: str = ""  # "rejected" or "allowed"
     fallback_status: str = ""  # "available" or ""
     rate_limit_error: str = ""  # error message if API call fails
@@ -1199,5 +1208,20 @@ def collect_all(config: dict[str, Any]) -> UsageStats:
         stats.peak_hint = ps.hint
     except Exception:
         stats.in_peak_window, stats.peak_hint = False, ""
+
+    # Optional second provider: OpenAI Codex (opt-in via `providers` config).
+    # collect_codex serves an on-disk cache between polls, so calling it on
+    # every refresh cycle is cheap; a failure just hides the Codex rows.
+    if "codex" in (config.get("providers") or []):
+        try:
+            cx = _codex.collect_codex(
+                poll_seconds=int(config.get("codex_poll_seconds", 300) or 300))
+            stats.codex_available = bool(cx["available"])
+            stats.codex_session_utilization = float(cx["session_pct"])
+            stats.codex_session_reset = int(cx["session_reset"])
+            stats.codex_weekly_utilization = float(cx["weekly_pct"])
+            stats.codex_weekly_reset = int(cx["weekly_reset"])
+        except Exception:
+            stats.codex_available = False
 
     return stats

--- a/claude_usage/collector.py
+++ b/claude_usage/collector.py
@@ -923,13 +923,16 @@ STATUSLINE_CACHE_MAX_AGE_SECONDS = 20 * 60
 
 
 def _load_statusline_rate_limits(
-    config: dict[str, Any], now_ts: float
+    config: dict[str, Any],
+    now_ts: float,
+    max_age_seconds: float = STATUSLINE_CACHE_MAX_AGE_SECONDS,
 ) -> dict[str, tuple[float, int]] | None:
     """Read a statusLine-dumped rate-limit file (see `statusline_cache_path`).
 
     Returns ``{"session": (pct, reset_ts), "weekly": (pct, reset_ts)}`` with
     expired windows clamped to zero, or None when the feature is disabled,
-    the file is missing/stale/from the future, or either window is absent.
+    the file is missing/older than ``max_age_seconds``/from the future, or
+    either window is absent.
     """
     path = str(config.get("statusline_cache_path", "") or "")
     if not path:
@@ -939,7 +942,7 @@ def _load_statusline_rate_limits(
             data = json.load(fh)
         captured = datetime.fromisoformat(str(data["captured_at"])).timestamp()
         age = now_ts - captured
-        if age > STATUSLINE_CACHE_MAX_AGE_SECONDS or age < -300:
+        if age > max_age_seconds or age < -300:
             return None
         limits = data["rate_limits"]
 
@@ -1010,10 +1013,48 @@ def collect_all(config: dict[str, Any]) -> UsageStats:
 
     stats.active_sessions = get_active_sessions(claude_dir)
 
-    rate_limits = fetch_rate_limits(claude_dir)
     now_ts = datetime.now().timestamp()
 
-    if "error" in rate_limits:
+    # Endpoint relief: when a statusLine dump is seconds-fresh, the endpoint
+    # has nothing newer to say about the session/weekly pair — skip the call
+    # and spend its budget at most once per `usage_endpoint_min_seconds`
+    # (scoped/overage data, and consumption from headless `claude -p` runs
+    # that never render a statusline, still need the real endpoint).
+    # `samples_path`'s mtime records the last *successful* endpoint fetch:
+    # append_sample/prune only run in the success branch below, and the
+    # statusline/skip paths deliberately never touch the file.
+    sl_live = _load_statusline_rate_limits(
+        config, now_ts,
+        max_age_seconds=2 * int(config.get("refresh_seconds", 60) or 60))
+    endpoint_min = int(config.get("usage_endpoint_min_seconds", 300) or 300)
+    try:
+        last_fetch_ts = os.path.getmtime(samples_path)
+    except OSError:
+        last_fetch_ts = 0.0
+    if sl_live is not None and (now_ts - last_fetch_ts) < endpoint_min:
+        stats.session_utilization, stats.session_reset = sl_live["session"]
+        stats.weekly_utilization, stats.weekly_reset = sl_live["weekly"]
+        # Scoped cap isn't in the statusline payload — carry the last
+        # sampled triple forward, clamping an expired window to zero.
+        try:
+            recent = load_samples(samples_path)
+        except OSError:
+            recent = []
+        for prev in reversed(recent):
+            if prev.get("scoped_label"):
+                scoped_reset = int(prev.get("scoped_reset", 0) or 0)
+                if not scoped_reset or now_ts < scoped_reset:
+                    stats.scoped_label = str(prev["scoped_label"])
+                    stats.scoped_utilization = float(prev.get("scoped", 0.0) or 0.0)
+                    stats.scoped_reset = scoped_reset
+                break
+        rate_limits = None
+    else:
+        rate_limits = fetch_rate_limits(claude_dir)
+
+    if rate_limits is None:
+        pass
+    elif "error" in rate_limits:
         stats.rate_limit_error = rate_limits["error"]
         # API call failed (transient network glitch, OAuth hiccup, etc.).
         # Without this, both utilization fields stay at the dataclass

--- a/claude_usage/config.py
+++ b/claude_usage/config.py
@@ -48,6 +48,13 @@ DEFAULT_CONFIG: Config = {
     # polls the on-disk cache is served. The RPC takes a couple of seconds,
     # so keep this much larger than refresh_seconds.
     "codex_poll_seconds": 300,
+    # Optional path to a JSON file a Claude Code statusLine command dumps its
+    # rate-limit payload to ({"captured_at": iso, "rate_limits": {"five_hour":
+    # {"used_percentage", "resets_at"}, "seven_day": {...}}}). When the
+    # /api/oauth/usage endpoint rate-limits us, a fresh copy of this file
+    # beats the last on-disk sample: Claude Code pushes it on every
+    # statusline render, at zero API cost. Empty = disabled.
+    "statusline_cache_path": "",
 
     # Max poll interval (seconds) the adaptive backoff climbs to when the API
     # rate-limits/errors; it snaps back to refresh_seconds on the next clean

--- a/claude_usage/config.py
+++ b/claude_usage/config.py
@@ -55,6 +55,12 @@ DEFAULT_CONFIG: Config = {
     # beats the last on-disk sample: Claude Code pushes it on every
     # statusline render, at zero API cost. Empty = disabled.
     "statusline_cache_path": "",
+    # With statusline_cache_path set: while the dump is seconds-fresh (an
+    # active session keeps rewriting it), skip the /api/oauth/usage call and
+    # only hit the endpoint at most once per this many seconds — it is a
+    # low-budget endpoint shared with Claude Code, and the scoped/overage
+    # fields plus headless consumption are all it's still needed for.
+    "usage_endpoint_min_seconds": 300,
 
     # Max poll interval (seconds) the adaptive backoff climbs to when the API
     # rate-limits/errors; it snaps back to refresh_seconds on the next clean

--- a/claude_usage/config.py
+++ b/claude_usage/config.py
@@ -40,6 +40,15 @@ DEFAULT_CONFIG: Config = {
     # budget (a low-volume endpoint shared with Claude Code).
     "refresh_seconds": 60,
 
+    # Which providers to collect. "claude" is always the primary; add "codex"
+    # to also poll the local OpenAI Codex CLI (`codex app-server`) and show
+    # its 5h/weekly rings & bars beneath Claude's. POSIX-only.
+    "providers": ["claude"],
+    # How often (seconds) to actually spawn the codex app-server RPC; between
+    # polls the on-disk cache is served. The RPC takes a couple of seconds,
+    # so keep this much larger than refresh_seconds.
+    "codex_poll_seconds": 300,
+
     # Max poll interval (seconds) the adaptive backoff climbs to when the API
     # rate-limits/errors; it snaps back to refresh_seconds on the next clean
     # refresh.

--- a/claude_usage/overlay.py
+++ b/claude_usage/overlay.py
@@ -806,9 +806,11 @@ class UsageOverlay(QWidget):
                 fill_color = _bar_color(pct, self._theme)
                 self._draw_ring(p, cx, cy, ring_d, ring_stroke, pct, fill_color)
 
-                # Percentage text centred in the ring.
-                pct_text = f"{int(pct * 100)}%"
-                pct_font_pt = max(10, int(13 * s))
+                # Utilisation number centred in the ring — no % sign, and
+                # sized off the ring diameter so it stays proportionate at
+                # every zoom level.
+                pct_text = f"{int(pct * 100)}"
+                pct_font_pt = max(12, int(ring_d * 0.30))
                 p.setFont(_mono_font(pct_font_pt, bold=True))
                 p.setPen(_hex_to_qcolor(self._theme["text_primary"]))
                 fm = p.fontMetrics()

--- a/claude_usage/overlay.py
+++ b/claude_usage/overlay.py
@@ -459,18 +459,39 @@ class UsageOverlay(QWidget):
 
     # ------------------------------------------------------------- internals
 
+    def _skin_base_height(self) -> float:
+        """Unscaled OSD height for the active skin, accounting for the optional
+        scoped-cap row and the optional Codex provider rows (5h + 7d).
+
+        ``_apply_size`` (window) and ``paint`` (the rect handed to paint_osd)
+        both derive their height here so they can never disagree — a mismatch
+        would let the extra rows spill outside the painted panel. Skins may
+        declare tuned ``osd_height_codex`` / ``osd_height_scoped_codex`` keys;
+        otherwise each extra row adds the skin's own scoped-row footprint.
+        """
+        m = self._skin.METRICS
+        base = m["osd_height"]
+        row = m.get("osd_height_scoped", base + SCOPED_ROW_HEIGHT) - base
+        scoped = bool(self._scoped_label)
+        codex = bool(self._codex_available)
+        if scoped and codex:
+            return m.get("osd_height_scoped_codex", base + 3 * row)
+        if codex:
+            return m.get("osd_height_codex", base + 2 * row)
+        if scoped:
+            return m.get("osd_height_scoped", base + row)
+        return base
+
     def _apply_size(self) -> None:
         """Resize the window to match ``_scale``, view mode, and chrome state."""
         if self._skin is not None and not self._minimized:
             # Skins declare their own OSD footprint — honour it instead of
             # squeezing the handoff layout into the default's 260×122 box.
-            # When a scoped weekly cap is present the skin draws a third row,
-            # so it exposes a taller "osd_height_scoped" we switch to.
+            # The taller scoped / Codex variants are resolved by
+            # _skin_base_height so the window matches the painted rect.
             m = self._skin.METRICS
             width = int(m["osd_width"] * self._scale)
-            base_h = m["osd_height"]
-            if self._scoped_label:
-                base_h = m.get("osd_height_scoped", m["osd_height"] + SCOPED_ROW_HEIGHT)
+            base_h = self._skin_base_height()
             height = int(base_h * self._scale)
             if self.isVisible():
                 tr = self.frameGeometry().topRight()
@@ -705,14 +726,10 @@ class UsageOverlay(QWidget):
             try:
                 s = self._scale
                 # Paint into the SAME rect height the window was sized to in
-                # _apply_size — the taller osd_height_scoped when a scoped cap
-                # is present — or the skin's panel/ticker only cover the base
-                # height and the third row spills outside the panel.
-                skin_base = self._skin.METRICS["osd_height"]
-                if self._scoped_label:
-                    skin_base = self._skin.METRICS.get(
-                        "osd_height_scoped", skin_base + SCOPED_ROW_HEIGHT)
-                skin_h = int(skin_base * s)
+                # _apply_size — the taller scoped / Codex variants resolved by
+                # _skin_base_height — or the skin's panel/ticker only cover the
+                # base height and the extra rows spill outside the panel.
+                skin_h = int(self._skin_base_height() * s)
                 self._skin.paint_osd(p, QRectF(0, 0, w, skin_h), data, self._scale)
                 # Draw news inside the skin's frame: above the skin's own ticker.
                 if getattr(self._skin, "WANTS_TICKER", False):

--- a/claude_usage/overlay.py
+++ b/claude_usage/overlay.py
@@ -53,6 +53,9 @@ SCOPED_ROW_HEIGHT = 31
 # stack vertically inside each column. No ticker in this view (it would
 # collide with the reset line under each ring).
 GAUGE_HEIGHT = 130
+# Extra height for the optional Codex ring row (a second Session/Weekly pair
+# drawn beneath Claude's; same stack minus the shared top padding).
+CODEX_GAUGE_ROW_HEIGHT = 118
 
 # Supported OSD view modes. Kept as string constants so config files and
 # tests don't have to import an enum.
@@ -83,9 +86,10 @@ MINIMIZED_HEIGHT = 6
 TICKER_SCROLL_PX_PER_SEC = 30.0
 TICKER_FRAME_INTERVAL_MS = 40  # ~25 fps — smooth without waking the CPU
 
-# Scroll-wheel scale limits
+# Scroll-wheel scale limits. 4.0 is deliberately generous — a gauge OSD
+# cranked all the way up works as a glance-from-across-the-room dashboard.
 SCALE_MIN = 0.6
-SCALE_MAX = 2.0
+SCALE_MAX = 4.0
 SCALE_STEP = 0.1
 
 # Distance the mouse must move between press and release before a left-click
@@ -217,6 +221,13 @@ class UsageOverlay(QWidget):
         self._scoped_pct: float = 0.0
         self._scoped_reset: int = 0
         self._scoped_label: str = ""
+        # Optional Codex provider (opt-in via `providers` config). When
+        # unavailable the OSD paints exactly as before.
+        self._codex_available: bool = False
+        self._codex_session_pct: float = 0.0
+        self._codex_session_reset: int = 0
+        self._codex_weekly_pct: float = 0.0
+        self._codex_weekly_reset: int = 0
         self._live_tpm: float = 0.0      # tokens/min over the last few minutes
         self._is_live: bool = False       # show the "● LIVE" dot
         self._burn_alert = None           # active burn/spike/storm badge (or None)
@@ -313,7 +324,17 @@ class UsageOverlay(QWidget):
         self._scoped_pct = max(0.0, min(1.0, float(getattr(stats, "scoped_utilization", 0.0))))
         self._scoped_reset = int(getattr(stats, "scoped_reset", 0) or 0)
         self._scoped_label = str(getattr(stats, "scoped_label", "") or "")
-        if bool(self._scoped_label) != had_scoped:
+        # Optional Codex provider rows — like scoped, their appearance or
+        # disappearance changes the OSD footprint.
+        had_codex = self._codex_available
+        self._codex_available = bool(getattr(stats, "codex_available", False))
+        self._codex_session_pct = max(0.0, min(1.0, float(
+            getattr(stats, "codex_session_utilization", 0.0) or 0.0)))
+        self._codex_session_reset = int(getattr(stats, "codex_session_reset", 0) or 0)
+        self._codex_weekly_pct = max(0.0, min(1.0, float(
+            getattr(stats, "codex_weekly_utilization", 0.0) or 0.0)))
+        self._codex_weekly_reset = int(getattr(stats, "codex_weekly_reset", 0) or 0)
+        if bool(self._scoped_label) != had_scoped or self._codex_available != had_codex:
             self._apply_size()
         live = getattr(stats, "live_activity", None)
         if live is not None:
@@ -462,6 +483,8 @@ class UsageOverlay(QWidget):
         width = int(BASE_WIDTH * self._scale)
         if self._view_mode == VIEW_MODE_GAUGE:
             base = GAUGE_HEIGHT + (SCOPED_ROW_HEIGHT if self._scoped_label else 0)
+            if self._codex_available:
+                base += CODEX_GAUGE_ROW_HEIGHT
         else:
             # Receipt skin always reserves the footer strip for its barcode,
             # even if the user disabled the ticker feature.
@@ -469,6 +492,8 @@ class UsageOverlay(QWidget):
             base = BASE_HEIGHT + (TICKER_STRIP_HEIGHT if wants_footer else 0)
             if self._scoped_label:
                 base += SCOPED_ROW_HEIGHT
+            if self._codex_available:
+                base += 2 * SCOPED_ROW_HEIGHT  # Codex 5h + 7d rows
         height = MINIMIZED_HEIGHT if self._minimized else int(base * self._scale)
         # Preserve the top-right corner when resizing so the overlay doesn't
         # visually drift as the user scrolls to scale.
@@ -758,45 +783,55 @@ class UsageOverlay(QWidget):
             )
 
         # Two columns splitting the panel; each column is one gauge stack.
+        # With the Codex provider active, a second row of rings (Codex 5h /
+        # 7d) is drawn beneath Claude's Session / Weekly pair.
         col_w = w / 2
         ring_d = max(50.0, min(col_w * 0.58, 80 * s))
         ring_stroke = max(4.0, 7 * s)
-        # Centre each ring inside its column, with room below for labels.
-        for idx, (label, pct, reset_ts) in enumerate((
+        ring_rows: list[tuple[tuple[str, float, int], ...]] = [(
             ("Session", self._session_pct, self._session_reset),
             ("Weekly",  self._weekly_pct,  self._weekly_reset),
-        )):
-            cx = col_w * idx + col_w / 2
-            cy = 12 * s + ring_d / 2
-            fill_color = _bar_color(pct, self._theme)
-            self._draw_ring(p, cx, cy, ring_d, ring_stroke, pct, fill_color)
+        )]
+        if self._codex_available:
+            ring_rows.append((
+                ("Codex 5h", self._codex_session_pct, self._codex_session_reset),
+                ("Codex 7d", self._codex_weekly_pct, self._codex_weekly_reset),
+            ))
+        # Centre each ring inside its column, with room below for labels.
+        for row_idx, row in enumerate(ring_rows):
+            row_top = (12 + row_idx * CODEX_GAUGE_ROW_HEIGHT) * s
+            for idx, (label, pct, reset_ts) in enumerate(row):
+                cx = col_w * idx + col_w / 2
+                cy = row_top + ring_d / 2
+                fill_color = _bar_color(pct, self._theme)
+                self._draw_ring(p, cx, cy, ring_d, ring_stroke, pct, fill_color)
 
-            # Percentage text centred in the ring.
-            pct_text = f"{int(pct * 100)}%"
-            pct_font_pt = max(10, int(13 * s))
-            p.setFont(_mono_font(pct_font_pt, bold=True))
-            p.setPen(_hex_to_qcolor(self._theme["text_primary"]))
-            fm = p.fontMetrics()
-            pct_w = fm.horizontalAdvance(pct_text)
-            p.drawText(QPointF(cx - pct_w / 2, cy + fm.ascent() / 2 - 2 * s), pct_text)
-
-            # Label + reset beneath the ring.
-            label_y = cy + ring_d / 2 + 14 * s
-            label_font_pt = max(8, int(9 * s))
-            p.setFont(_mono_font(label_font_pt, bold=True))
-            p.setPen(_hex_to_qcolor(self._theme["text_primary"]))
-            fm = p.fontMetrics()
-            lw = fm.horizontalAdvance(label)
-            p.drawText(QPointF(cx - lw / 2, label_y), label)
-
-            reset_label = _format_reset_short(reset_ts)
-            if reset_label:
-                reset_font_pt = max(7, int(7.5 * s))
-                p.setFont(_mono_font(reset_font_pt))
-                p.setPen(_hex_to_qcolor(self._theme["text_dim"]))
+                # Percentage text centred in the ring.
+                pct_text = f"{int(pct * 100)}%"
+                pct_font_pt = max(10, int(13 * s))
+                p.setFont(_mono_font(pct_font_pt, bold=True))
+                p.setPen(_hex_to_qcolor(self._theme["text_primary"]))
                 fm = p.fontMetrics()
-                rw = fm.horizontalAdvance(reset_label)
-                p.drawText(QPointF(cx - rw / 2, label_y + 12 * s), reset_label)
+                pct_w = fm.horizontalAdvance(pct_text)
+                p.drawText(QPointF(cx - pct_w / 2, cy + fm.ascent() / 2 - 2 * s), pct_text)
+
+                # Label + reset beneath the ring.
+                label_y = cy + ring_d / 2 + 14 * s
+                label_font_pt = max(8, int(9 * s))
+                p.setFont(_mono_font(label_font_pt, bold=True))
+                p.setPen(_hex_to_qcolor(self._theme["text_primary"]))
+                fm = p.fontMetrics()
+                lw = fm.horizontalAdvance(label)
+                p.drawText(QPointF(cx - lw / 2, label_y), label)
+
+                reset_label = _format_reset_short(reset_ts)
+                if reset_label:
+                    reset_font_pt = max(7, int(7.5 * s))
+                    p.setFont(_mono_font(reset_font_pt))
+                    p.setPen(_hex_to_qcolor(self._theme["text_dim"]))
+                    fm = p.fontMetrics()
+                    rw = fm.horizontalAdvance(reset_label)
+                    p.drawText(QPointF(cx - rw / 2, label_y + 12 * s), reset_label)
 
         # Burn / spike badge — centred along the top strip, which sits clear
         # above both ring tops (rings begin at y = 12·s; the gauge draws no
@@ -989,6 +1024,20 @@ class UsageOverlay(QWidget):
                 reset_label=_format_reset_short(self._scoped_reset),
             )
             y2 = y3  # push the footer below the extra row
+
+        # --- Codex provider rows — only when the codex provider is active ---
+        if self._codex_available:
+            for label, pct, reset_ts in (
+                ("Codex 5h", self._codex_session_pct, self._codex_session_reset),
+                ("Codex 7d", self._codex_weekly_pct, self._codex_weekly_reset),
+            ):
+                y2 = y2 + 15 * s + bar_h + 10 * s
+                self._draw_row(
+                    p, y2, w, pad_x, bar_w, bar_h, bar_r, font_label, font_small,
+                    label=label,
+                    pct=pct,
+                    reset_label=_format_reset_short(reset_ts),
+                )
 
         # --- Ticker strip / receipt footer (below the weekly row) ---
         # Receipt skin replaces the scrolling ticker with a dotted

--- a/claude_usage/skins/_adapter.py
+++ b/claude_usage/skins/_adapter.py
@@ -40,6 +40,16 @@ class SkinData:
     scoped_reset_hrs: int = 0
     scoped_reset_min: int = 0
     scoped_label: str = ""
+    # Optional OpenAI Codex provider (opt-in via `providers` config). All
+    # Codex rows are gated on codex_available; when False the skins render
+    # byte-for-byte as before. Mirrors the scoped-cap convention above, but
+    # as two rows — Codex 5h (session-like) and Codex 7d (weekly-like).
+    codex_available: bool = False
+    codex_session_pct: float = 0.0
+    codex_session_reset_min: int = 0
+    codex_weekly_pct: float = 0.0
+    codex_weekly_reset_hrs: int = 0
+    codex_weekly_reset_min: int = 0
     live_tok_per_min: float = 0.0  # in thousands (e.g. 10.5 means 10.5k)
     is_live: bool = False
     subagent_count: int = 0
@@ -260,6 +270,25 @@ def from_usage_stats(
             scoped_reset_hrs = sc_left // 3600
             scoped_reset_min = (sc_left % 3600) // 60
 
+    # Codex provider — present only when the opt-in second provider is active.
+    # codex_*_reset are epoch timestamps (like session/weekly/scoped), so they
+    # are converted to the same minutes / hours+minutes shape here.
+    codex_available = bool(getattr(stats, "codex_available", False))
+    codex_session_pct = codex_weekly_pct = 0.0
+    codex_session_reset_min = codex_weekly_reset_hrs = codex_weekly_reset_min = 0
+    if codex_available:
+        codex_session_pct = max(0.0, min(1.0, float(
+            getattr(stats, "codex_session_utilization", 0.0) or 0.0)))
+        if getattr(stats, "codex_session_reset", 0) > 0:
+            cs_left = max(0, int(stats.codex_session_reset - now_ts))
+            codex_session_reset_min = cs_left // 60
+        codex_weekly_pct = max(0.0, min(1.0, float(
+            getattr(stats, "codex_weekly_utilization", 0.0) or 0.0)))
+        if getattr(stats, "codex_weekly_reset", 0) > 0:
+            cw_left = max(0, int(stats.codex_weekly_reset - now_ts))
+            codex_weekly_reset_hrs = cw_left // 3600
+            codex_weekly_reset_min = (cw_left % 3600) // 60
+
     live = getattr(stats, "live_activity", None)
     tpm = float(getattr(live, "tokens_per_minute", 0.0) or 0.0)
     is_live = bool(getattr(live, "is_live", False))
@@ -285,6 +314,12 @@ def from_usage_stats(
         scoped_reset_hrs=scoped_reset_hrs,
         scoped_reset_min=scoped_reset_min,
         scoped_label=scoped_label,
+        codex_available=codex_available,
+        codex_session_pct=codex_session_pct,
+        codex_session_reset_min=codex_session_reset_min,
+        codex_weekly_pct=codex_weekly_pct,
+        codex_weekly_reset_hrs=codex_weekly_reset_hrs,
+        codex_weekly_reset_min=codex_weekly_reset_min,
         live_tok_per_min=tpm / 1000.0,
         is_live=is_live,
         subagent_count=int(getattr(stats, "active_subagent_count", 0) or 0),

--- a/claude_usage/skins/brutalist.py
+++ b/claude_usage/skins/brutalist.py
@@ -59,6 +59,10 @@ METRICS = {
     # + 14px bar + 9pt reset line + spacing) — so the third row drops in below
     # WEEKLY without crowding the ticker strip.
     "osd_height_scoped": 286,
+    # +2 rows for the optional Codex 5h / 7d pair (same ~62px row footprint as
+    # the scoped cap); scoped_codex stacks all three extra rows below WEEKLY.
+    "osd_height_codex": 348,
+    "osd_height_scoped_codex": 410,
 }
 
 FONTS = {"family_mono": "Space Mono", "body_pt": 10, "title_pt": 11}
@@ -150,6 +154,15 @@ def paint_osd(p: QPainter, rect: QRectF, data, scale: float = 1.0) -> None:
     if data.scoped_pct is not None and data.scoped_label:
         yy = row(yy, data.scoped_label.upper(), data.scoped_pct,
                  f"RESETS {data.scoped_reset_hrs}H {data.scoped_reset_min}M",
+                 t["ink"])
+
+    # Optional Codex provider — two native rows in the SESSION/WEEKLY idiom,
+    # gated on codex_available so the no-Codex panel stays byte-for-byte.
+    if data.codex_available:
+        yy = row(yy, "CODEX 5H", data.codex_session_pct,
+                 f"RESETS {data.codex_session_reset_min}M", t["accent"])
+        yy = row(yy, "CODEX 7D", data.codex_weekly_pct,
+                 f"RESETS {data.codex_weekly_reset_hrs}H {data.codex_weekly_reset_min}M",
                  t["ink"])
 
     # 2px rule above the ticker strip — matches the Swiss-grid section

--- a/claude_usage/skins/dashboard.py
+++ b/claude_usage/skins/dashboard.py
@@ -51,7 +51,11 @@ THEME = {
 }
 
 METRICS = {
-    "osd_width": 380, "osd_height": 196, "osd_height_scoped": 256, "osd_radius": 8, "osd_padding": 14,
+    "osd_width": 380, "osd_height": 196, "osd_height_scoped": 256,
+    # +2 rows for the optional Codex 5h / 7d pair (same 60px row footprint as
+    # the scoped cap); scoped_codex stacks all three extra rows.
+    "osd_height_codex": 316, "osd_height_scoped_codex": 376,
+    "osd_radius": 8, "osd_padding": 14,
     "popup_width": 540, "popup_padding": 18,
     "ring_size": 58, "ring_stroke": 6, "row_bar_height": 4,
     "ticker_h": 24,
@@ -134,6 +138,17 @@ def paint_osd(p: QPainter, rect: QRectF, data, scale: float = 1.0) -> None:
         rows.append((
             (data.scoped_label or "SCOPED").upper(), data.scoped_pct,
             f"{data.scoped_reset_hrs}h {data.scoped_reset_min}m", t["accent2"],
+        ))
+    # Optional Codex provider — two native rows (5h / 7d) in the same idiom,
+    # gated on codex_available so the no-Codex panel is byte-for-byte unchanged.
+    if data.codex_available:
+        rows.append((
+            "CODEX 5H", data.codex_session_pct,
+            f"{data.codex_session_reset_min}m", t["accent"],
+        ))
+        rows.append((
+            "CODEX 7D", data.codex_weekly_pct,
+            f"{data.codex_weekly_reset_hrs}h {data.codex_weekly_reset_min}m", t["accent2"],
         ))
     y_cursor = y + fm.height() + 8 * s
     fm_metric = QFontMetrics(metric_f)

--- a/claude_usage/skins/hud.py
+++ b/claude_usage/skins/hud.py
@@ -56,6 +56,9 @@ THEME = {
 
 METRICS = {
     "osd_width": 360, "osd_height": 220, "osd_height_scoped": 370,
+    # Codex 5h / 7d render as ONE extra gauge row (a side-by-side pair, like
+    # SESSION/WEEKLY), so codex adds a single 150px gauge row — not two.
+    "osd_height_codex": 370, "osd_height_scoped_codex": 520,
     "osd_radius": 10, "osd_padding": 14,
     "ring_size": 118, "ring_stroke": 10,
     "ring_size_popup": 140, "ring_stroke_popup": 12,
@@ -149,11 +152,13 @@ def paint_osd(p: QPainter, rect: QRectF, data, scale: float = 1.0) -> None:
     # 270° gauge centred below the SESSION/WEEKLY pair. Present only when the
     # API reports it; otherwise the OSD renders byte-for-byte as before.
     scoped_present = data.scoped_pct is not None
+    codex_present = data.codex_available
 
-    # gauges — equally spaced. When a scoped gauge is present the pair stays
-    # anchored to the original-height centre (top of the taller window) so the
-    # third gauge can sit beneath it and the ticker slides down to the bottom.
-    if scoped_present:
+    # gauges — equally spaced. When a scoped gauge and/or the Codex pair is
+    # present the SESSION/WEEKLY pair stays anchored to the original-height
+    # centre (top of the taller window) so the extra rows sit beneath it and
+    # the ticker slides down to the bottom.
+    if scoped_present or codex_present:
         y_mid = rect.y() + m["osd_height"] * s / 2 + 10 * s
     else:
         y_mid = rect.y() + rect.height() / 2 + 10 * s
@@ -187,6 +192,20 @@ def paint_osd(p: QPainter, rect: QRectF, data, scale: float = 1.0) -> None:
         y_scoped = y_mid + (m["osd_height_scoped"] - m["osd_height"]) * s
         paint_gauge(p, cx, y_scoped, data.scoped_pct, scoped_label,
                     f"{data.scoped_reset_hrs}h {data.scoped_reset_min}m", s)
+
+    # Codex provider — one extra gauge row rendered as a CODEX 5H / CODEX 7D
+    # pair in the same two columns as SESSION/WEEKLY, using the identical
+    # renderer/fonts/spacing. Gated on codex_available so the no-Codex OSD is
+    # byte-for-byte. When a scoped gauge is also present the pair drops one
+    # further row beneath it.
+    if codex_present:
+        codex_key = "osd_height_scoped_codex" if scoped_present else "osd_height_codex"
+        y_codex = y_mid + (m[codex_key] - m["osd_height"]) * s
+        paint_gauge(p, rect.x() + third * 0.5, y_codex, data.codex_session_pct,
+                    "CODEX 5H", f"{data.codex_session_reset_min}m", s)
+        paint_gauge(p, rect.x() + third * 2.5, y_codex, data.codex_weekly_pct,
+                    "CODEX 7D",
+                    f"{data.codex_weekly_reset_hrs}h {data.codex_weekly_reset_min}m", s)
 
     # Ticker strip along the bottom — bordered separator + amber-tiered
     # quartile colours matching the cockpit palette.

--- a/claude_usage/skins/receipt.py
+++ b/claude_usage/skins/receipt.py
@@ -57,6 +57,10 @@ METRICS = {
     # +1 receipt row (fm.height()≈15 + the 16px SESSION→WEEKLY rhythm) for the
     # optional scoped weekly cap; the overlay switches to this when present.
     "osd_height_scoped": 265,
+    # +2 receipt rows for the optional Codex 5h / 7d pair (same ~31px row
+    # rhythm as the scoped cap); scoped_codex stacks all three extra rows.
+    "osd_height_codex": 296,
+    "osd_height_scoped_codex": 327,
     "popup_width": 540, "popup_padding": 26,
     "grain_step_px": 3, "ticker_h": 22,
 }
@@ -167,6 +171,27 @@ def paint_osd(p: QPainter, rect: QRectF, data, scale: float = 1.0) -> None:
         p.drawRect(QRectF(x, yy, w, 8 * s))
         p.setPen(Qt.NoPen); p.setBrush(hex_to_qcolor(t["ink"]))
         p.drawRect(QRectF(x, yy, w * data.scoped_pct, 8 * s))
+
+    # CODEX — optional 5h / 7d pair, each mirroring the WEEKLY row exactly.
+    # Gated on codex_available so the no-Codex receipt is byte-for-byte.
+    if data.codex_available:
+        for c_label, c_pct, c_reset in (
+            ("CODEX 5H", data.codex_session_pct, f"{data.codex_session_reset_min}m"),
+            ("CODEX 7D", data.codex_weekly_pct,
+             f"{data.codex_weekly_reset_hrs}h{data.codex_weekly_reset_min}m"),
+        ):
+            yy += 8 * s + 6 * s
+            draw_text(p, x, yy + fm.ascent(), c_label,
+                      hex_to_qcolor(t["ink"]), body_f)
+            right = f"{int(c_pct * 100)}% · {c_reset}"
+            rw = fm.horizontalAdvance(right)
+            draw_text(p, x + w - rw, yy + fm.ascent(), right,
+                      hex_to_qcolor(t["ink"]), body_f)
+            yy += fm.height() + 2 * s
+            p.setPen(hex_to_qcolor(t["rule"])); p.setBrush(hex_to_qcolor(t["bar_track"]))
+            p.drawRect(QRectF(x, yy, w, 8 * s))
+            p.setPen(Qt.NoPen); p.setBrush(hex_to_qcolor(t["ink"]))
+            p.drawRect(QRectF(x, yy, w * c_pct, 8 * s))
 
     # Ticker marquee (between the weekly bar and the thank-you footer).
     yy += 8 * s + 6 * s

--- a/claude_usage/skins/strip.py
+++ b/claude_usage/skins/strip.py
@@ -45,6 +45,9 @@ THEME = {
 
 METRICS = {
     "osd_width": 480, "osd_height": 54, "osd_height_scoped": 108,
+    # Codex 5h / 7d render as ONE extra strip row (a CODEX 5H | CODEX 7D pair
+    # side-by-side, like SESSION | WEEKLY), so codex adds a single 54px row.
+    "osd_height_codex": 108, "osd_height_scoped_codex": 162,
     "osd_radius": 8, "osd_padding": 0,
     "seg_title_w": 96, "seg_live_w": 96,
     "bar_h": 3,
@@ -170,6 +173,25 @@ def paint_osd(p: QPainter, rect: QRectF, data, scale: float = 1.0) -> None:
         seg(xs, mid_w * 2, data.scoped_label.upper(), scoped_pct,
             f"{data.scoped_reset_hrs}h", t["accent2"],
             top=base_bottom, bh=base_h)
+
+    # Codex provider — one extra strip row (CODEX 5H | CODEX 7D side-by-side,
+    # same seg() painter as SESSION | WEEKLY). Gated on codex_available so the
+    # no-Codex strip is byte-for-byte. Drops below the scoped row when present.
+    if data.codex_available:
+        codex_top = base_bottom + (base_h if (scoped_pct is not None
+                                              and getattr(data, "scoped_label", "")) else 0.0)
+        p.setPen(hex_to_qcolor(t["border"]))
+        p.drawLine(QPointF(rect.x() + 4 * s, codex_top),
+                   QPointF(rect.right() - 4 * s, codex_top))
+        seg(xs, mid_w, "CDX 5H", data.codex_session_pct,
+            f"{data.codex_session_reset_min}m", t["accent"],
+            top=codex_top, bh=base_h)
+        p.setPen(hex_to_qcolor(t["border"]))
+        p.drawLine(QPointF(xs + mid_w, codex_top + 4 * s),
+                   QPointF(xs + mid_w, codex_top + base_h - 4 * s))
+        seg(xs + mid_w, mid_w, "CDX 7D", data.codex_weekly_pct,
+            f"{data.codex_weekly_reset_hrs}h", t["accent2"],
+            top=codex_top, bh=base_h)
 
 
 # ---- POPUP ---------------------------------------------------------

--- a/claude_usage/skins/terminal.py
+++ b/claude_usage/skins/terminal.py
@@ -61,6 +61,9 @@ METRICS = {
     "osd_width":       440,
     "osd_height":      172,
     "osd_height_scoped": 212,  # +1 Session/Weekly row footprint (2*line_h + row_gap + 2)
+    # +2 rows for the optional Codex 5h / 7d pair (same 40px row footprint).
+    "osd_height_codex": 252,
+    "osd_height_scoped_codex": 292,
     "osd_radius":      6,
     "osd_padding":     12,
     "osd_row_gap":     8,
@@ -164,6 +167,27 @@ def paint_osd(p: QPainter, rect: QRectF, data, scale: float = 1.0) -> None:
                        m["osd_bar_cols"],
                        hex_to_qcolor(t["accent"]), hex_to_qcolor(t["very_dim"]),
                        body_f)
+
+    # Codex provider rows — optional 5h / 7d pair, each mirroring the weekly
+    # row exactly. Gated on codex_available so the no-Codex OSD is unchanged.
+    if data.codex_available:
+        for c_label, c_pct, c_reset in (
+            ("codex 5h", data.codex_session_pct, f"{data.codex_session_reset_min}m"),
+            ("codex 7d", data.codex_weekly_pct,
+             f"{data.codex_weekly_reset_hrs}h {data.codex_weekly_reset_min}m"),
+        ):
+            y_row = y_bar + line_h + m["osd_row_gap"] * s
+            draw_text(p, x, y_row + fm.ascent(), c_label,
+                      hex_to_qcolor(t["text_secondary"]), body_f)
+            right = f"{c_reset} · {int(c_pct * 100)}%"
+            rw = fm.horizontalAdvance(right)
+            draw_text(p, x + w - rw, y_row + fm.ascent(), right,
+                      hex_to_qcolor(t["text_secondary"]), body_f)
+            y_bar = y_row + line_h + 2 * s
+            draw_ascii_bar(p, x, y_bar + fm.ascent(), c_pct,
+                           m["osd_bar_cols"],
+                           hex_to_qcolor(t["accent"]), hex_to_qcolor(t["very_dim"]),
+                           body_f)
 
     # ticker strip — dashed separator + colour-quartile cost tags
     y_tick = y_bar + line_h + 6 * s

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1,0 +1,64 @@
+"""Tests for the opt-in Codex provider (claude_usage.codex)."""
+
+import time
+
+from claude_usage.codex import _clamp_expired, parse_rate_limits
+
+
+FUTURE = int(time.time()) + 3600
+
+
+def _payload(primary=None, secondary=None):
+    limits = {}
+    if primary is not None:
+        limits["primary"] = primary
+    if secondary is not None:
+        limits["secondary"] = secondary
+    return {"rateLimits": limits}
+
+
+def test_parse_both_windows():
+    parsed = parse_rate_limits(_payload(
+        primary={"usedPercent": 54.2, "resetsAt": FUTURE, "windowDurationMins": 300},
+        secondary={"usedPercent": 12.0, "resetsAt": FUTURE + 86400},
+    ))
+    assert parsed == {
+        "session_pct": 0.542,
+        "session_reset": FUTURE,
+        "weekly_pct": 0.12,
+        "weekly_reset": FUTURE + 86400,
+    }
+
+
+def test_parse_single_window_and_clamping():
+    parsed = parse_rate_limits(_payload(primary={"usedPercent": 250.0, "resetsAt": None}))
+    assert parsed is not None
+    assert parsed["session_pct"] == 1.0  # clamped to 0..1
+    assert parsed["session_reset"] == 0
+    assert parsed["weekly_pct"] == 0.0
+
+
+def test_parse_millisecond_resets_normalised():
+    parsed = parse_rate_limits(_payload(primary={"usedPercent": 10, "resetsAt": FUTURE * 1000}))
+    assert parsed is not None
+    assert parsed["session_reset"] == FUTURE
+
+
+def test_parse_rejects_unusable_payloads():
+    assert parse_rate_limits(None) is None
+    assert parse_rate_limits({}) is None
+    assert parse_rate_limits({"rateLimits": "nope"}) is None
+    assert parse_rate_limits(_payload()) is None
+    assert parse_rate_limits(_payload(primary={"usedPercent": None})) is None
+    assert parse_rate_limits(_payload(primary={"usedPercent": "NaN%"})) is None
+
+
+def test_clamp_expired_windows_roll_back_to_zero():
+    now = time.time()
+    parsed = {
+        "session_pct": 0.9, "session_reset": int(now - 60),
+        "weekly_pct": 0.4, "weekly_reset": int(now + 3600),
+    }
+    out = _clamp_expired(parsed, now)
+    assert out["session_pct"] == 0.0 and out["session_reset"] == 0
+    assert out["weekly_pct"] == 0.4 and out["weekly_reset"] == int(now + 3600)

--- a/tests/test_skin_codex_rows.py
+++ b/tests/test_skin_codex_rows.py
@@ -1,0 +1,125 @@
+"""Codex provider rows in the self-drawn OSD skins.
+
+Follow-up to the merchant-OSD Codex rows (PR #18): the six paint-your-own
+skins consume :class:`SkinData` rather than the overlay's ``UsageStats``, so
+they needed their own Codex 5h / 7d rows. These tests lock three things:
+
+1. the adapter converts the Codex epoch resets to the same minutes /
+   hours+minutes shape the rows render;
+2. every skin renders with the Codex provider active without raising, at the
+   taller ``osd_height_*codex`` footprint; and
+3. the rows are strictly gated on ``codex_available`` — a panel with the flag
+   off is byte-for-byte identical whether or not Codex values are populated
+   (the opt-in / byte-identical-by-default contract).
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import QRectF  # noqa: E402
+from PySide6.QtGui import QImage, QPainter, QColor  # noqa: E402
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+from claude_usage.skins import SKIN_MODULES  # noqa: E402
+from claude_usage.skins._adapter import SkinData, from_usage_stats  # noqa: E402
+
+_app = QApplication.instance() or QApplication([])
+
+
+def _skin_data(*, codex: bool, codex_vals: bool = True, scoped: bool = False) -> SkinData:
+    return SkinData(
+        session_pct=0.42, session_reset_min=137,
+        weekly_pct=0.68, weekly_reset_hrs=52, weekly_reset_min=30,
+        scoped_pct=0.55 if scoped else None,
+        scoped_label="Fable" if scoped else "",
+        scoped_reset_hrs=40, scoped_reset_min=0,
+        codex_available=codex,
+        # When codex_vals is True these carry real numbers even with the flag
+        # off — the gate must ignore them entirely.
+        codex_session_pct=0.31 if codex_vals else 0.0,
+        codex_session_reset_min=245 if codex_vals else 0,
+        codex_weekly_pct=0.77 if codex_vals else 0.0,
+        codex_weekly_reset_hrs=88 if codex_vals else 0,
+        codex_weekly_reset_min=15 if codex_vals else 0,
+    )
+
+
+def _render(mod, data: SkinData, *, scoped: bool) -> bytes:
+    m = mod.METRICS
+    key = "osd_height_scoped_codex" if scoped else "osd_height_codex"
+    if not data.codex_available:
+        key = "osd_height_scoped" if scoped else "osd_height"
+    w = int(m["osd_width"])
+    h = int(m.get(key, m["osd_height"]))
+    img = QImage(w, h, QImage.Format_ARGB32)
+    img.fill(QColor("#101014"))
+    p = QPainter(img)
+    try:
+        mod.paint_osd(p, QRectF(0, 0, w, h), data, 1.0)
+    finally:
+        p.end()
+    return bytes(img.constBits())
+
+
+class TestCodexAdapter:
+    def test_reset_timestamps_convert_to_minutes_and_hours(self) -> None:
+        now = 1_000_000
+        stats = SimpleNamespace(
+            codex_available=True,
+            codex_session_utilization=0.31,
+            codex_session_reset=now + 245 * 60,          # 245m out
+            codex_weekly_utilization=0.77,
+            codex_weekly_reset=now + 88 * 3600 + 15 * 60,  # 88h 15m out
+        )
+        d = from_usage_stats(stats, now=now)
+        assert d.codex_available is True
+        assert d.codex_session_pct == 0.31
+        assert d.codex_session_reset_min == 245
+        assert d.codex_weekly_reset_hrs == 88
+        assert d.codex_weekly_reset_min == 15
+
+    def test_absent_provider_leaves_codex_fields_zeroed(self) -> None:
+        d = from_usage_stats(SimpleNamespace(), now=1_000_000)
+        assert d.codex_available is False
+        assert d.codex_session_pct == 0.0
+        assert d.codex_session_reset_min == 0
+        assert d.codex_weekly_reset_hrs == 0
+
+    def test_utilization_is_clamped(self) -> None:
+        stats = SimpleNamespace(
+            codex_available=True,
+            codex_session_utilization=1.9,
+            codex_weekly_utilization=-0.2,
+        )
+        d = from_usage_stats(stats, now=0)
+        assert d.codex_session_pct == 1.0
+        assert d.codex_weekly_pct == 0.0
+
+
+class TestSkinCodexRows:
+    def test_every_skin_declares_codex_height_metrics(self) -> None:
+        for name, mod in SKIN_MODULES.items():
+            m = mod.METRICS
+            assert "osd_height_codex" in m, name
+            assert "osd_height_scoped_codex" in m, name
+            assert m["osd_height_codex"] >= m["osd_height"], name
+            assert m["osd_height_scoped_codex"] >= m["osd_height_scoped"], name
+
+    def test_every_skin_renders_with_codex_active(self) -> None:
+        for name, mod in SKIN_MODULES.items():
+            for scoped in (False, True):
+                data = _skin_data(codex=True, scoped=scoped)
+                # Must not raise for any skin × (codex-only, scoped+codex).
+                assert _render(mod, data, scoped=scoped), name
+
+    def test_absent_codex_is_byte_identical(self) -> None:
+        # The opt-in contract: with codex_available False, a panel carrying
+        # populated Codex numbers must render identically to one carrying the
+        # zeroed defaults — i.e. the flag fully gates the extra rows.
+        for name, mod in SKIN_MODULES.items():
+            with_vals = _render(mod, _skin_data(codex=False, codex_vals=True), scoped=False)
+            without_vals = _render(mod, _skin_data(codex=False, codex_vals=False), scoped=False)
+            assert with_vals == without_vals, name


### PR DESCRIPTION
Follow-up to #18. You noted the skins paint their own OSD so they didn't pick up the Codex rows yet — this wires them in. The six paint-your-own skins consume `SkinData` rather than the overlay's `UsageStats`, so the Codex provider needed its own field + a per-skin row.

## What changed
- **`SkinData` gains the Codex fields** (`codex_available`, `codex_session/weekly` pct + resets), populated in `from_usage_stats` from the same `UsageStats` fields the overlay reads. The `codex_*_reset` epoch timestamps are converted to the minutes / hours+minutes shape the rows render, mirroring how session/weekly/scoped already do it.
- **Each skin draws Codex rows in its own idiom**, after the scoped row: the bar skins (dashboard, brutalist, receipt, terminal) stack two rows (Codex 5h / 7d); the ring skin (hud) and the dense strip draw a side-by-side pair — matching how the overlay's gauge vs bars modes render them. strip abbreviates to `CDX 5H/7D` so the label clears the pct in its narrow segment.
- **Height resolution is now one helper.** Each skin's `METRICS` gains `osd_height_codex` / `osd_height_scoped_codex`, and `_apply_size` (window) + `paint` (rect) both derive the skin height via a single `_skin_base_height()` so they can't disagree across the four {scoped, codex} combinations and let a row spill outside the panel.

## Opt-in / byte-identical by default
Every Codex row is gated on `codex_available`, so a panel with the provider off renders exactly as before. Popup path is untouched (kept the scope to the OSD, like #18).

## Tests
`tests/test_skin_codex_rows.py`:
- adapter reset-timestamp → minutes/hours conversion + clamping;
- a render pass over all six skins × {codex, scoped+codex} (offscreen);
- **byte-identical gate** — with `codex_available` off, populated Codex values render byte-for-byte identical to the zeroed defaults.

Full suite: 445 passed. Rendered all six skins offscreen (codex-only and scoped+codex) to eyeball the rows in each skin's chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)