### PR TITLE
Raise max scroll-wheel zoom from 2.0x to 4.0x

### DIFF
--- a/claude_usage/overlay.py
+++ b/claude_usage/overlay.py
@@ -88,7 +88,7 @@ TICKER_FRAME_INTERVAL_MS = 40  # ~25 fps — smooth without waking the CPU
 
 # Scroll-wheel scale limits
 SCALE_MIN = 0.6
-SCALE_MAX = 2.0
+SCALE_MAX = 4.0
 SCALE_STEP = 0.1
 
 # Distance the mouse must move between press and release before a left-click


### PR DESCRIPTION
As you offered in #21 — splitting out the `SCALE_MAX` bump on its own.

Raises the scroll-wheel zoom ceiling from 2.0x to 4.0x. `SCALE_MIN` and `SCALE_STEP` are unchanged, so the default size and existing scroll behavior are unaffected — this only extends the upper bound of the zoom range.

**Use case:** on high-DPI / large displays the 2.0x cap leaves the OSD quite small when tucked in a corner as a glanceable indicator; 4.0x keeps it readable from across the room.